### PR TITLE
Update helper script from to use the compose command in the Docker CLI

### DIFF
--- a/scripts/itkdev-docker-compose
+++ b/scripts/itkdev-docker-compose
@@ -287,7 +287,7 @@ fi
 docker_compose () {
     # Note: Apparently, using --project-directory or --file options for `docker-compose` will break use of `$PWD` in
     # docker-compose.yml. Therefore, we `cd` before running `docker-compose` command.
-    (cd "$docker_compose_dir" && COMPOSE_DOMAIN=${COMPOSE_DOMAIN} docker-compose "$@")
+    (cd "$docker_compose_dir" && COMPOSE_DOMAIN=${COMPOSE_DOMAIN} docker compose "$@")
 }
 
 cmd="$1"
@@ -399,11 +399,11 @@ EOF
 
   traefik:start)
     docker network inspect frontend >/dev/null 2>&1 || docker network create --driver=bridge --attachable --internal=false frontend
-    $(cd ${script_dir}/../traefik/; docker-compose up -d)
+    $(cd ${script_dir}/../traefik/; docker compose up -d)
     ;;
 
   traefik:stop)
-    $(cd ${script_dir}/../traefik/; docker-compose down --volumes)
+    $(cd ${script_dir}/../traefik/; docker compose down --volumes)
     ;;
 
   traefik:open)


### PR DESCRIPTION
Unsure if we should merge this as long as it is as a Tech Preview:

>The `compose` command in the Docker CLI is currently available as a Tech Preview.

https://docs.docker.com/compose/cli-command/

> The Docker CLI now supports the `compose` command, including most of the `docker-compose` features and flags, without the need for a separate tool.
> 
> You can replace the dash (`-`) with a space when you use `docker-compose` to switch over to `docker compose`. You can also use them interchangeably, so that you are not locked-in with the new `compose` command and, if needed, you can still use `docker-compose`.