### PR TITLE
Increaase fastcgi_buffers in nginx config to avoid upstream sent too big header errors

### DIFF
--- a/templates/aakbcms/.docker/vhost.conf
+++ b/templates/aakbcms/.docker/vhost.conf
@@ -74,6 +74,10 @@ server {
     # pattern with front controllers other than update.php in a future
     # release.
     location ~ '\.php$|^/update.php' {
+        fastcgi_buffers 16 32k;
+        fastcgi_buffer_size 64k;
+        fastcgi_busy_buffers_size 64k;
+
         fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
         # Security note: If you're running a version of PHP older than the
         # latest 5.3, you should have "cgi.fix_pathinfo = 0;" in php.ini.

--- a/templates/ddbcms/.docker/vhost.conf
+++ b/templates/ddbcms/.docker/vhost.conf
@@ -74,6 +74,10 @@ server {
     # pattern with front controllers other than update.php in a future
     # release.
     location ~ '\.php$|^/update.php' {
+        fastcgi_buffers 16 32k;
+        fastcgi_buffer_size 64k;
+        fastcgi_busy_buffers_size 64k;
+
         fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
         # Security note: If you're running a version of PHP older than the
         # latest 5.3, you should have "cgi.fix_pathinfo = 0;" in php.ini.

--- a/templates/drupal-7/.docker/vhost.conf
+++ b/templates/drupal-7/.docker/vhost.conf
@@ -49,6 +49,10 @@ server {
     }
 
     location ~ '\.php$|^/update.php' {
+        fastcgi_buffers 16 32k;
+        fastcgi_buffer_size 64k;
+        fastcgi_busy_buffers_size 64k;
+
         fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
         include fastcgi_params;
 
@@ -73,7 +77,7 @@ server {
         expires max;
         log_not_found off;
     }
-    
+
     error_log /dev/stderr;
     access_log /dev/stdout main;
 }

--- a/templates/drupal-8/.docker/vhost.conf
+++ b/templates/drupal-8/.docker/vhost.conf
@@ -54,6 +54,10 @@ server {
     }
 
     location ~ '\.php$|^/update.php' {
+        fastcgi_buffers 16 32k;
+        fastcgi_buffer_size 64k;
+        fastcgi_busy_buffers_size 64k;
+
         fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
         include fastcgi_params;
 

--- a/templates/drupal-9/.docker/vhost.conf
+++ b/templates/drupal-9/.docker/vhost.conf
@@ -54,6 +54,10 @@ server {
     }
 
     location ~ '\.php$|^/update.php' {
+        fastcgi_buffers 16 32k;
+        fastcgi_buffer_size 64k;
+        fastcgi_busy_buffers_size 64k;
+
         fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
         include fastcgi_params;
 

--- a/templates/ereolen/.docker/vhost.conf
+++ b/templates/ereolen/.docker/vhost.conf
@@ -54,6 +54,10 @@ server {
   }
 
   location ~ \.php$ {
+    fastcgi_buffers 16 32k;
+    fastcgi_buffer_size 64k;
+    fastcgi_busy_buffers_size 64k;
+
     fastcgi_split_path_info ^(.+\.php)(/.+)$;
     fastcgi_pass phpfpm:9000;
     fastcgi_index index.php;

--- a/templates/symfony-3/.docker/vhost.conf
+++ b/templates/symfony-3/.docker/vhost.conf
@@ -11,6 +11,10 @@ server {
 
     # Development
     location ~ ^/(app_dev|config)\.php(/|$) {
+        fastcgi_buffers 16 32k;
+        fastcgi_buffer_size 64k;
+        fastcgi_busy_buffers_size 64k;
+
         fastcgi_pass phpfpm:9000;
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;

--- a/templates/symfony-4/.docker/vhost.conf
+++ b/templates/symfony-4/.docker/vhost.conf
@@ -9,6 +9,10 @@ server {
     }
 
     location ~ ^/index\.php(/|$) {
+        fastcgi_buffers 16 32k;
+        fastcgi_buffer_size 64k;
+        fastcgi_busy_buffers_size 64k;
+
         fastcgi_pass phpfpm:9000;
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;

--- a/templates/symfony-6/.docker/vhost.conf
+++ b/templates/symfony-6/.docker/vhost.conf
@@ -9,6 +9,10 @@ server {
     }
 
     location ~ ^/index\.php(/|$) {
+        fastcgi_buffers 16 32k;
+        fastcgi_buffer_size 64k;
+        fastcgi_busy_buffers_size 64k;
+
         fastcgi_pass phpfpm:9000;
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;


### PR DESCRIPTION
https://jira.itkdev.dk/browse/SERV-635

We have on a number of projects seen this `upstream sent too big header while reading response header from upstream` while developing locally.

This results in a `502 Bad Gateway` and is diffucult to debug because it is not related to the project code. Setting the following in the Nginx conf fixes the problem:

```
fastcgi_buffers 16 32k;
fastcgi_buffer_size 64k;
fastcgi_busy_buffers_size 64k;
```

```
nyhedslisten-nginx-1  | 2023/02/22 11:11:54 [error] 26#26: *37 upstream sent too big header while reading response header from upstream, client: 172.18.0.2, server: localhost, request: "GET /?crudAction=index&crudControllerFqcn=App%5CController%5CAdmin%5CSearchRunCrudController HTTP/1.1", upstream: "fastcgi://192.168.112.3:9000", host: "nyhedslisten.local.itkdev.dk", referrer: "http://nyhedslisten.local.itkdev.dk/?referrer=%2F%3FcrudAction%3Dindex%26crudControllerFqcn%3DApp%255CController%255CAdmin%255CMaterialCrudController&crudAction=index&crudControllerFqcn=App%5CController%5CAdmin%5CMaterialCrudController&filters%5BcoverUrl%5D%5Bcomparison%5D=like&filters%5BcoverUrl%5D%5Bvalue%5D=cloudi"
```