### PR TITLE
Resurrected xdebug command

### DIFF
--- a/completion/bash/itkdev-docker-compose-completion.bash
+++ b/completion/bash/itkdev-docker-compose-completion.bash
@@ -9,7 +9,7 @@ _idc_completions()
   fi
 
   # Keep the suggestions in a local variable
-  local suggestions=($(compgen -W "dory:start dory:stop url open drush nfs:enable template:install traefik:start traefik:stop traefik:open traefik:url mail:open mail:url mailhog:open mailhog:url sql:connect sql:log sql:port sql:open xdebug hosts:insert self:update sync sync:db sync:files images:pull composer php version bin/console" -- "${COMP_WORDS[1]}"))
+  local suggestions=($(compgen -W "dory:start dory:stop url open drush nfs:enable template:install traefik:start traefik:stop traefik:open traefik:url mail:open mail:url mailhog:open mailhog:url sql:connect sql:log sql:port sql:open xdebug xdebug3 hosts:insert self:update sync sync:db sync:files images:pull composer php version bin/console" -- "${COMP_WORDS[1]}"))
 
   COMPREPLY=("${suggestions[@]}")
 

--- a/completion/bash/itkdev-docker-compose-completion.bash
+++ b/completion/bash/itkdev-docker-compose-completion.bash
@@ -9,7 +9,7 @@ _idc_completions()
   fi
 
   # Keep the suggestions in a local variable
-  local suggestions=($(compgen -W "dory:start dory:stop url open drush nfs:enable template:install traefik:start traefik:stop traefik:open traefik:url mail:open mail:url mailhog:open mailhog:url sql:connect sql:log sql:port sql:open xdebug xdebug2 xdebug3 hosts:insert self:update sync sync:db sync:files images:pull composer php version bin/console" -- "${COMP_WORDS[1]}"))
+  local suggestions=($(compgen -W "dory:start dory:stop url open drush nfs:enable template:install traefik:start traefik:stop traefik:open traefik:url mail:open mail:url mailhog:open mailhog:url sql:connect sql:log sql:port sql:open xdebug hosts:insert self:update sync sync:db sync:files images:pull composer php version bin/console" -- "${COMP_WORDS[1]}"))
 
   COMPREPLY=("${suggestions[@]}")
 

--- a/completion/zsh/_itkdev-docker-compose
+++ b/completion/zsh/_itkdev-docker-compose
@@ -51,6 +51,7 @@ _itkdev-docker-compose() {
               'mailhog\:url[URL for the mailhog web-interface.]' \
               'mailhog\:open[Open mailhog url in default browser.]' \
               'xdebug[Start the containers with Xdebug enabled.]' \
+              'xdebug3[Start the containers with Xdebug enabled.]' \
               'hosts\:insert[Insert the docker site url into the hosts file.]' \
               'images\:pull[Update/pull all docker images.]' \
               'composer[Run composer command inside phpfpm container.]' \

--- a/completion/zsh/_itkdev-docker-compose
+++ b/completion/zsh/_itkdev-docker-compose
@@ -50,9 +50,7 @@ _itkdev-docker-compose() {
               'mail\:open[Open mail url in default browser.]' \
               'mailhog\:url[URL for the mailhog web-interface.]' \
               'mailhog\:open[Open mailhog url in default browser.]' \
-              'xdebug[Deprecated command use xdebug2 (PHP =< 7.2) or xdebug3 (PHP >= 7.3).]' \
-              'xdebug2[Boot the containers with PHP xdebug support enabled (PHP =< 7.2).]' \
-              'xdebug3[Boot the containers with PHP xdebug support enabled (PHP >= 7.3).]' \
+              'xdebug[Start the containers with Xdebug enabled.]' \
               'hosts\:insert[Insert the docker site url into the hosts file.]' \
               'images\:pull[Update/pull all docker images.]' \
               'composer[Run composer command inside phpfpm container.]' \

--- a/scripts/itkdev-docker-compose
+++ b/scripts/itkdev-docker-compose
@@ -2,6 +2,12 @@
 VERSION=3.0.0
 set -o errexit -o errtrace -o noclobber -o nounset -o pipefail
 IFS=$'\n\t'
+bold=$(tput -Txterm-256color bold)
+normal=$(tput -Txterm-256color sgr0)
+
+# @see https://stackoverflow.com/a/54839008
+fg_black_8=$(tput setf 0)
+bg_green_8=$(tput setb 2)
 
 function find_script_dir {
   local script=${BASH_SOURCE[0]}
@@ -227,6 +233,10 @@ Commands:
   xdebug
                 Boot the containers with PHP xdebug support enabled.
 
+  xdebug3
+                Boot the containers with PHP xdebug support enabled.
+                Consider using `xdebug` for an improved developer experience.
+
   hosts:insert
                 Insert the docker site url into the hosts file.
 
@@ -287,6 +297,14 @@ Configuration:
 EOF
 }
 
+function message_info() {
+  echo "${bg_green_8}${fg_black_8}"
+  echo
+  echo "  ""$@""  "
+  echo "${normal}"
+  echo
+}
+
 # Start PHP service with Xdebug enabled, wait for kill signal and restart with
 # Xdebug disabled.
 function xdebug() {
@@ -345,9 +363,7 @@ Configuration… > "PHP: Listen for Xdebug"):
 
 EOF
 
-  echo
-  echo "Starting Docker Compose with Xdebug enabled. Press Ctrl-C to disable Xdebug."
-  echo
+  message_info "Starting Docker Compose with Xdebug enabled. Press Ctrl-C to disable."
 
   # Needed to use `trap`
   set +o errexit
@@ -668,11 +684,67 @@ EOF
     ;;
 
   xdebug3)
-    echo
-    echo "Deprecated command use xdebug"
-    echo
+    PHP_XDEBUG_MODE=debug \
+    PHP_XDEBUG_WITH_REQUEST=yes \
+    docker_compose up -d
 
-    xdebug
+    cat <<'EOF' | sed "s|«project directory»|$PWD|"
+
+================================================================================
+
+Make sure that `PHP_IDE_CONFIG=serverName=localhost` is set in the `phpfpm`
+service environment:
+
+# docker-compose.yml
+phpfpm:
+    image: …
+    environment:
+      …
+      - PHP_IDE_CONFIG=serverName=localhost
+
+# PhpStorm
+
+Open Preferences > PHP > Servers and define "localhost" as a server:
+
+Name: localhost
+Host: localhost
+Port: 8080
+Debugger: Xdebug
+Path mapping: «project directory» → /app
+
+You may also want to uncheck "Force break at first line when no path mapping
+specified" and/or "Force break at first line when a script is outside the
+project" in PhpStorm (Preferences > Languages & Frameworks > PHP > Debug).
+
+# VS Code
+
+Install https://marketplace.visualstudio.com/items?itemName=xdebug.php-debug
+
+Add a configuration in `.vscode/launch.json` with `pathMappings` (Run > Add
+Configuration… > "PHP: Listen for Xdebug"):
+
+{
+    …
+    "configurations": [
+        …,
+        {
+            "name": "Listen for Xdebug",
+            "type": "php",
+            "request": "launch",
+            "port": 9003,
+            "pathMappings": {
+                "/app": "${workspaceFolder}"
+            }
+        }
+    ]
+}
+
+================================================================================
+
+EOF
+
+    message_info "Consider using \`$(basename $script_path) xdebug\` for an improved developer experience."
+
     ;;
 
   hosts:insert)

--- a/scripts/itkdev-docker-compose
+++ b/scripts/itkdev-docker-compose
@@ -287,6 +287,86 @@ Configuration:
 EOF
 }
 
+# Start PHP service with Xdebug enabled, wait for kill signal and restart with
+# Xdebug disabled.
+function xdebug() {
+  cat <<'EOF' | sed "s|«project directory»|$PWD|"
+
+================================================================================
+
+Make sure that `PHP_IDE_CONFIG=serverName=localhost` is set in the `phpfpm`
+service environment:
+
+# docker-compose.yml
+phpfpm:
+    image: …
+    environment:
+      …
+      - PHP_IDE_CONFIG=serverName=localhost
+
+# PhpStorm
+
+Open Preferences > PHP > Servers and define "localhost" as a server:
+
+Name: localhost
+Host: localhost
+Port: 8080
+Debugger: Xdebug
+Path mapping: «project directory» → /app
+
+You may also want to uncheck "Force break at first line when no path mapping
+specified" and/or "Force break at first line when a script is outside the
+project" in PhpStorm (Preferences > Languages & Frameworks > PHP > Debug).
+
+# VS Code
+
+Install https://marketplace.visualstudio.com/items?itemName=xdebug.php-debug
+
+Add a configuration in `.vscode/launch.json` with `pathMappings` (Run > Add
+Configuration… > "PHP: Listen for Xdebug"):
+
+{
+    …
+    "configurations": [
+        …,
+        {
+            "name": "Listen for Xdebug",
+            "type": "php",
+            "request": "launch",
+            "port": 9003,
+            "pathMappings": {
+                "/app": "${workspaceFolder}"
+            }
+        }
+    ]
+}
+
+================================================================================
+
+EOF
+
+  echo
+  echo "Starting Docker Compose with Xdebug enabled. Press Ctrl-C to disable Xdebug."
+  echo
+
+  # Needed to use `trap`
+  set +o errexit
+
+  # https://stackoverflow.com/a/11952947
+  trap " " INT
+  # Start the docker compose with Xdebug enabled
+  # @todo Should we disable logs, e.g. by sending it to /dev/null?
+  PHP_XDEBUG_MODE=debug PHP_XDEBUG_WITH_REQUEST=yes docker_compose up
+  trap - INT
+
+  # Disable Xdebug.
+  echo
+  echo "Starting Docker Compose with Xdebug disabled."
+  echo
+
+  docker_compose up --detach
+}
+
 # template:install must be run before we check for existence of compose file.
 if [[ "$#" -gt "0" && "$1" == "template:install" ]]; then
   shift
@@ -584,103 +664,15 @@ EOF
     ;;
 
   xdebug)
-    echo "Deprecated command use xdebug2 (PHP =< 7.2) or xdebug3 (PHP >= 7.3)"
-    ;;
-
-  xdebug2)
-    PHP_XDEBUG_REMOTE_ENABLE=1 \
-    PHP_XDEBUG_REMOTE_AUTOSTART=1 \
-    docker_compose up -d
-
-    cat <<'EOF' | sed "s|«project directory»|$PWD|"
-
-================================================================================
-
-To debug from the command line, add `PHP_IDE_CONFIG=serverName=localhost` to the
-`phpfpm` environment:
-
-# docker-compose.yml
-phpfpm:
-    image: itkdev/php7.2-fpm:latest
-    environment:
-      …
-      - PHP_IDE_CONFIG=serverName=localhost
-
-and define "localhost" as a server in PhpStorm (Preferences > Languages &
-Frameworks > PHP > Servers):
-
-Name: localhost
-Host: localhost
-Path mapping: «project directory» → /app
-
-You may also want to uncheck "Force break at first line when no path mapping
-specified" and/or "Force break at first line when a script is outside the
-project" in PhpStorm (Preferences > Languages & Frameworks > PHP > Debug).
-
-================================================================================
-
-EOF
+    xdebug
     ;;
 
   xdebug3)
-    PHP_XDEBUG_MODE=debug \
-    PHP_XDEBUG_WITH_REQUEST=yes \
-    docker_compose up -d
+    echo
+    echo "Deprecated command use xdebug"
+    echo
 
-    cat <<'EOF' | sed "s|«project directory»|$PWD|"
-
-================================================================================
-
-Make sure that `PHP_IDE_CONFIG=serverName=localhost` is set in the `phpfpm`
-service environment:
-
-# docker-compose.yml
-phpfpm:
-    image: …
-    environment:
-      …
-      - PHP_IDE_CONFIG=serverName=localhost
-
-# PhpStorm
-
-Open Preferences > PHP > Servers and define "localhost" as a server:
-
-Name: localhost
-Host: localhost
-Port: 8080
-Debugger: Xdebug
-Path mapping: «project directory» → /app
-
-You may also want to uncheck "Force break at first line when no path mapping
-specified" and/or "Force break at first line when a script is outside the
-project" in PhpStorm (Preferences > Languages & Frameworks > PHP > Debug).
-
-# VS Code
-
-Install https://marketplace.visualstudio.com/items?itemName=xdebug.php-debug
-
-Add a configuration in `.vscode/launch.json` with `pathMappings` (Run > Add
-Configuration… > "PHP: Listen for Xdebug"):
-
-{
-    …
-    "configurations": [
-        …,
-        {
-            "name": "Listen for Xdebug",
-            "type": "php",
-            "request": "launch",
-            "port": 9003,
-            "pathMappings": {
-                "/app": "${workspaceFolder}"
-            }
-        }
-    ]
-}
-
-================================================================================
-
-EOF
+    xdebug
     ;;
 
   hosts:insert)


### PR DESCRIPTION
Resurrects the `xdebug` command and makes the use of it a little more efficient: When running `itkdev-docker-compose xdebug`, the PHP service will be started with Xdebug enabled, and then we'll wait for a kill signal and restart the PHP service with Xdebug disabled. This (hopefully) encourages more efficient use of debugging, i.e

1. Enable Xdebug
2. Debug whatever needs to be debugged
3. DIsable Xdebug – and get back on the fast track (with Xdebug disabled)

Futhermore, this pull request removes the `xdebug2` command (which was needed only for `PHP` ≤ 7.2).

