### PR TITLE
Run mysql client inside mariadb container

### DIFF
--- a/completion/bash/itkdev-docker-compose-completion.bash
+++ b/completion/bash/itkdev-docker-compose-completion.bash
@@ -9,7 +9,7 @@ _idc_completions()
   fi
 
   # Keep the suggestions in a local variable
-  local suggestions=($(compgen -W "dory:start dory:stop url open drush nfs:enable template:install traefik:start traefik:stop traefik:open traefik:url mail:open mail:url mailhog:open mailhog:url sql:connect sql:log sql:port sql:open xdebug xdebug3 hosts:insert self:update sync sync:db sync:files images:pull composer php version bin/console" -- "${COMP_WORDS[1]}"))
+  local suggestions=($(compgen -W "dory:start dory:stop url open drush nfs:enable template:install traefik:start traefik:stop traefik:open traefik:url mail:open mail:url mailhog:open mailhog:url sql:cli sql:connect sql:log sql:port sql:open xdebug xdebug3 hosts:insert self:update sync sync:db sync:files images:pull composer php version bin/console" -- "${COMP_WORDS[1]}"))
 
   COMPREPLY=("${suggestions[@]}")
 

--- a/completion/zsh/_itkdev-docker-compose
+++ b/completion/zsh/_itkdev-docker-compose
@@ -37,6 +37,7 @@ _itkdev-docker-compose() {
               'sync[Sync both database and files.]' \
               'sync\:db[Sync database base.]' \
               'sync\:files[Sync files base.]' \
+              'sql\:cli[Open mysql cli.]' \
               'sql\:connect[Print mysql command for connecting to database.]' \
               'sql\:log[Log SQL queries sent to database.]' \
               'sql\:port[Display the exposed MariaDB SQL server port.]' \

--- a/scripts/itkdev-docker-compose
+++ b/scripts/itkdev-docker-compose
@@ -193,6 +193,14 @@ Commands:
                 Use `$(itkdev-docker-compose sql:connect)` to open the
                 database cli.
 
+                Execute a SQL query from the command line:
+
+                  $(itkdev-docker-compose sql:connect) --table <<< 'SHOW TABLES'
+
+                Run a SQL script:
+
+                  $(itkdev-docker-compose sql:connect) < query.sql
+
   sql:log
                 Log SQL queries sent to database.
 
@@ -609,10 +617,8 @@ EOF
     ;;
 
   sql:connect)
-    address=$(docker_compose port mariadb 3306)
-    host=$(echo $address | cut -d: -f1)
-    port=$(echo $address | cut -d: -f2)
-    echo mysql --host=$host --port=$port --user=db --password=db db
+    db_service=mariadb
+    echo docker compose exec --no-TTY $db_service mysql --user=db --password=db db
     ;;
 
   sql:open)

--- a/scripts/itkdev-docker-compose
+++ b/scripts/itkdev-docker-compose
@@ -186,20 +186,24 @@ Commands:
                 Sync files base on 'REMOTE_PATH' or 'LOCAL_PATH' in
                 the env file.
 
+  sql:cli
+                Open MySQL client to the database (named `db`) in the database
+                container (`mariadb`).
+
+                Execute a SQL query from the command line:
+
+                  itkdev-docker-compose sql:cli --table <<< 'SHOW TABLES'
+
+                Run a SQL script:
+
+                  itkdev-docker-compose sql:cli < query.sql
+
   sql:connect
                 Print mysql command for connecting to database (named
                 `db`) in the database container (`mariadb`).
 
                 Use `$(itkdev-docker-compose sql:connect)` to open the
                 database cli.
-
-                Execute a SQL query from the command line:
-
-                  $(itkdev-docker-compose sql:connect) --table <<< 'SHOW TABLES'
-
-                Run a SQL script:
-
-                  $(itkdev-docker-compose sql:connect) < query.sql
 
   sql:log
                 Log SQL queries sent to database.
@@ -572,7 +576,7 @@ case "$cmd" in
     fi
 
     if command -v pv >/dev/null 2>&1; then
-      ssh ${REMOTE_HOST} ${REMOTE_DB_DUMP_CMD} | pv | eval $(itkdev-docker-compose sql:connect)
+      ssh ${REMOTE_HOST} ${REMOTE_DB_DUMP_CMD} | pv | $script_path sql:cli
     else
       cat <<EOF
 Protip: run
@@ -581,7 +585,7 @@ Protip: run
 
 to show progress
 EOF
-      ssh ${REMOTE_HOST} ${REMOTE_DB_DUMP_CMD} | eval $(itkdev-docker-compose sql:connect)
+      ssh ${REMOTE_HOST} ${REMOTE_DB_DUMP_CMD} | $script_path sql:cli
     fi
 
     if [ ! -z "${SYNC_DB_POST_SCRIPT:-}" ]; then
@@ -616,9 +620,19 @@ EOF
     eval rsync -avz ${excludes} ${REMOTE_HOST}:${REMOTE_PATH}/ ${docker_compose_dir}/${LOCAL_PATH}
     ;;
 
+  sql:cli)
+    db_service=mariadb
+    exec_args=()
+    # @see https://stackoverflow.com/a/2456870?
+    if ! [ -t 0 ]; then
+      exec_args+=("--no-TTY")
+    fi
+    docker compose exec "${exec_args[@]}" $db_service mysql --user=db --password=db --database=db "$@"
+    ;;
+
   sql:connect)
     db_service=mariadb
-    echo docker compose exec --no-TTY $db_service mysql --user=db --password=db db
+    echo docker compose exec $db_service mysql --user=db --password=db db
     ;;
 
   sql:open)


### PR DESCRIPTION
Updates the `itkdev-docker-compose sql:connect` command to run `mysql` inside the database container rather than assuming we have `mysql` installed on our local machine[^1]:

[^1]: We probably have, but we don't need to.

Before:

``` shell
$ itkdev-docker-compose sql:connect
mysql --host=0.0.0.0 --port=53661 --user=db --password=db db
$ $(itkdev-docker-compose sql:connect)
ERROR 2026 (HY000): TLS/SSL error: SSL is required, but the server does not support it
```

After:

``` shell
$ itkdev-docker-compose sql:connect
docker compose exec mariadb mysql --user=db --password=db db
$ $(itkdev-docker-compose sql:connect)
Welcome to the MariaDB monitor.  Commands end with ; or \g.
…
```

Furthermore, a new command, `itkdev-docker-compose sql:cli`, is introduced. This command allows us to easily drop into a MySQL session:

``` shell
$ itkdev-docker-compose sql:cli
Welcome to the MariaDB monitor.  Commands end with ; or \g.
…
``` 

or send SQL commands to the database:

``` shell
bash-5.2$ itkdev-docker-compose sql:cli <<< 'SHOW TABLES' 
Tables_in_db
actions
advagg_aggregates
…
```
