### PR TITLE
Set serversTransport.insecureSkipVerifyAdded in Traefik config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `serversTransport.insecureSkipVerifyAdded` in Trafik config (cf.
+  <https://doc.traefik.io/traefik/routing/services/#insecureskipverify>).
+
 ### Removed
 
 - Removed `nfs` volume usage for better MacOS Ventura compatibility

--- a/traefik/traefik.yml
+++ b/traefik/traefik.yml
@@ -19,3 +19,7 @@ providers:
   docker:
     endpoint: "tcp://socket-proxy:2375"
     exposedByDefault: false
+
+# https://doc.traefik.io/traefik/routing/services/#insecureskipverify
+serversTransport:
+  insecureSkipVerify: true


### PR DESCRIPTION
Sets `serversTransport.insecureSkipVerifyAdded` in Trafik config (cf. <https://doc.traefik.io/traefik/routing/services/#insecureskipverify>).
