### PR TITLE
Add DRUSH_OPTIONS_URI to env for phpfpm container

### DIFF
--- a/templates/drupal-10/docker-compose.server.yml
+++ b/templates/drupal-10/docker-compose.server.yml
@@ -17,6 +17,9 @@ services:
     environment:
       - PHP_MAX_EXECUTION_TIME=30
       - PHP_MEMORY_LIMIT=128M
+      - COMPOSER_VERSION=2
+      # Let drush know the site uri (makes using --uri redundant)
+      - DRUSH_OPTIONS_URI=https://${COMPOSE_SERVER_DOMAIN}
     depends_on:
       - memcached
     volumes:

--- a/templates/drupal-10/docker-compose.server.yml
+++ b/templates/drupal-10/docker-compose.server.yml
@@ -17,7 +17,6 @@ services:
     environment:
       - PHP_MAX_EXECUTION_TIME=30
       - PHP_MEMORY_LIMIT=128M
-      - COMPOSER_VERSION=2
       # Let drush know the site uri (makes using --uri redundant)
       - DRUSH_OPTIONS_URI=https://${COMPOSE_SERVER_DOMAIN}
     depends_on:

--- a/templates/drupal-10/docker-compose.yml
+++ b/templates/drupal-10/docker-compose.yml
@@ -44,6 +44,8 @@ services:
       - PHP_SENDMAIL_PATH=/usr/bin/msmtp --host=mail --port=1025 --read-recipients --read-envelope-from
       - DOCKER_HOST_DOMAIN=${COMPOSE_DOMAIN}
       - PHP_IDE_CONFIG=serverName=localhost
+      # Let drush know the site uri (makes using --uri redundant)
+      - DRUSH_OPTIONS_URI=http://${COMPOSE_DOMAIN}
     depends_on:
       mariadb:
         condition: service_healthy

--- a/templates/drupal-9/docker-compose.server.yml
+++ b/templates/drupal-9/docker-compose.server.yml
@@ -17,6 +17,9 @@ services:
     environment:
       - PHP_MAX_EXECUTION_TIME=30
       - PHP_MEMORY_LIMIT=128M
+      - COMPOSER_VERSION=2
+      # Let drush know the site uri (makes using --uri redundant)
+      - DRUSH_OPTIONS_URI=https://${COMPOSE_SERVER_DOMAIN}
     depends_on:
       - memcached
     volumes:

--- a/templates/drupal-9/docker-compose.server.yml
+++ b/templates/drupal-9/docker-compose.server.yml
@@ -17,7 +17,6 @@ services:
     environment:
       - PHP_MAX_EXECUTION_TIME=30
       - PHP_MEMORY_LIMIT=128M
-      - COMPOSER_VERSION=2
       # Let drush know the site uri (makes using --uri redundant)
       - DRUSH_OPTIONS_URI=https://${COMPOSE_SERVER_DOMAIN}
     depends_on:

--- a/templates/drupal-9/docker-compose.yml
+++ b/templates/drupal-9/docker-compose.yml
@@ -44,6 +44,8 @@ services:
       - PHP_SENDMAIL_PATH=/usr/bin/msmtp --host=mail --port=1025 --read-recipients --read-envelope-from
       - DOCKER_HOST_DOMAIN=${COMPOSE_DOMAIN}
       - PHP_IDE_CONFIG=serverName=localhost
+      # Let drush know the site uri (makes using --uri redundant)
+      - DRUSH_OPTIONS_URI=http://${COMPOSE_DOMAIN}
     depends_on:
       mariadb:
         condition: service_healthy


### PR DESCRIPTION
Use `DRUSH_OPTIONS_URI` (https://www.drush.org/13.x/using-drush-configuration/#environment-variables) to set site uri in drush options. This makes using `--uri` redundant.

Note: This is also helpful for setting cron tasks in Woodpecker workflows because we no longer needs to duplicate the site uri in the workflow files.