### PR TITLE
Added general .editorconfig file

### DIFF
--- a/config/drupal-module/.editorconfig
+++ b/config/drupal-module/.editorconfig
@@ -1,0 +1,27 @@
+# This file is copied from config/drupal-module/.editorconfig in https://github.com/itk-dev/devops_itkdev-docker.
+# Feel free to edit the file, but consider making a pull request if you find a general issue with the file.
+
+# EditorConfig is awesome: https://editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+charset = utf-8
+end_of_line = LF
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{js,css,scss}]
+indent_size = 2
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[config/sync/**/*.{yml,yaml}]
+indent_size = 2
+
+[*.{php,install,module,theme}]
+indent_size = 2

--- a/config/drupal/.editorconfig
+++ b/config/drupal/.editorconfig
@@ -1,0 +1,24 @@
+# This file is copied from config/drupal/.editorconfig in https://github.com/itk-dev/devops_itkdev-docker.
+# Feel free to edit the file, but consider making a pull request if you find a general issue with the file.
+
+# EditorConfig is awesome: https://editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+charset = utf-8
+end_of_line = LF
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{js,css,scss}]
+indent_size = 2
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[web/*/custom/**/*.{php,install,module,theme}]
+indent_size = 2

--- a/config/symfony/.editorconfig
+++ b/config/symfony/.editorconfig
@@ -1,0 +1,24 @@
+# This file is copied from config/symfony/.editorconfig in https://github.com/itk-dev/devops_itkdev-docker.
+# Feel free to edit the file, but consider making a pull request if you find a general issue with the file.
+
+# EditorConfig is awesome: https://editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+charset = utf-8
+end_of_line = LF
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{js,css,scss}]
+indent_size = 2
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[config/**/*.{yml,yaml}]
+indent_size = 4

--- a/task/scripts/github-actions-link
+++ b/task/scripts/github-actions-link
@@ -38,6 +38,21 @@ for template_dir in templates/*; do
     exit 1
   fi
 
+  # General config files.
+  # We first check for files on the config folder and then we check for project
+  # specific files (in effect letting projects override the general config
+  # files).
+  for config_dir in config "config/$project_type"; do
+    echo "$config_dir"
+    # Some config files are hidden
+    GLOBIGNORE=".:.."
+    for config_file in "$config_dir"/*; do
+      if [ -f "$config_file" ]; then
+            ln -sf "../../$config_file" "$template_dir/"
+      fi
+    done
+  done
+
   for f in $(find github/workflows/ -name '*.yaml' | sort); do
     source_file_name=''
     # Note: / is NOT a regex delimiter here, but an actual /, i.e. a directory separator.

--- a/templates/drupal-10/.editorconfig
+++ b/templates/drupal-10/.editorconfig
@@ -1,0 +1,1 @@
+../../config/drupal/.editorconfig

--- a/templates/drupal-11/.editorconfig
+++ b/templates/drupal-11/.editorconfig
@@ -1,0 +1,1 @@
+../../config/drupal/.editorconfig

--- a/templates/drupal-7/.editorconfig
+++ b/templates/drupal-7/.editorconfig
@@ -1,0 +1,1 @@
+../../config/drupal/.editorconfig

--- a/templates/drupal-8/.editorconfig
+++ b/templates/drupal-8/.editorconfig
@@ -1,0 +1,1 @@
+../../config/drupal/.editorconfig

--- a/templates/drupal-9/.editorconfig
+++ b/templates/drupal-9/.editorconfig
@@ -1,0 +1,1 @@
+../../config/drupal/.editorconfig

--- a/templates/drupal-module/.editorconfig
+++ b/templates/drupal-module/.editorconfig
@@ -1,0 +1,1 @@
+../../config/drupal-module/.editorconfig

--- a/templates/symfony-3/.editorconfig
+++ b/templates/symfony-3/.editorconfig
@@ -1,0 +1,1 @@
+../../config/symfony/.editorconfig

--- a/templates/symfony-4/.editorconfig
+++ b/templates/symfony-4/.editorconfig
@@ -1,0 +1,1 @@
+../../config/symfony/.editorconfig

--- a/templates/symfony-6/.editorconfig
+++ b/templates/symfony-6/.editorconfig
@@ -1,0 +1,1 @@
+../../config/symfony/.editorconfig


### PR DESCRIPTION
Adds [`.editorconfig`](https://editorconfig.org/) files for all project types.

The config files are based on [the one matching Prettier's opinion](https://prettier.io/docs/configuration#editorconfig) and the 40[^1] [`.editorconfig` files in our projects](https://github.com/search?q=org%3Aitk-dev+.editorconfig+language%3AEditorConfig&type=code&l=EditorConfig).

[^1]: at the time of writing