### PR TITLE
Update to actions/checkout@v5 and go-task/setup-task@v1

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -10,11 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Check that Github Actions documentation is up to date
     steps:
-      - uses: actions/checkout@v4
-      - uses: arduino/setup-task@v2
-        # https://github.com/arduino/setup-task/tree/56d0cc033e3cecc5f07a291fdd39f29388d21800?tab=readme-ov-file#repo-token
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v5
+      - uses: go-task/setup-task@v1
 
       # https://github.com/mxschmitt/action-tmate?tab=readme-ov-file#manually-triggered-debug
       # Enable tmate debugging if debug logging is enabled (cf.
@@ -34,10 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Check that Github Actions template headers are up to date
     steps:
-      - uses: actions/checkout@v4
-      - uses: arduino/setup-task@v2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v5
+      - uses: go-task/setup-task@v1
       - run: |
           task github-actions:template-headers:update --yes
       # Check that files have not changed.
@@ -48,10 +43,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Check that config file headers are up to date
     steps:
-      - uses: actions/checkout@v4
-      - uses: arduino/setup-task@v2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v5
+      - uses: go-task/setup-task@v1
       - run: |
           task github-actions:config-headers:update --yes
       # Check that files have not changed.
@@ -62,10 +55,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Check that workflow and config file links are up to date
     steps:
-      - uses: actions/checkout@v4
-      - uses: arduino/setup-task@v2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v5
+      - uses: go-task/setup-task@v1
       - run: |
           task github-actions:link --yes
       # Check that files have not changed.
@@ -75,19 +66,15 @@ jobs:
   lint-markdown:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: arduino/setup-task@v2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v5
+      - uses: go-task/setup-task@v1
       - run: |
           SKIP_FIX=1 task lint:markdown
 
   lint-shell-script:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: arduino/setup-task@v2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v5
+      - uses: go-task/setup-task@v1
       - run: |
           SKIP_FIX=1 task lint:shell-script

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Create docker network
         run: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,7 +17,7 @@ jobs:
           - symfony-6
     name: Validate compose (${{ matrix.version }})
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v5
 
       - name: Validate local docker compose files
         run: |

--- a/.github/workflows/workflow-template.yaml
+++ b/.github/workflows/workflow-template.yaml
@@ -6,7 +6,7 @@ jobs:
   check-yaml:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - run: |
           docker pull mikefarah/yq
@@ -17,10 +17,8 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: arduino/setup-task@v2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v5
+      - uses: go-task/setup-task@v1
 
       - run: |
           task lint:shell-script

--- a/.github/workflows/yaml.yaml
+++ b/.github/workflows/yaml.yaml
@@ -31,7 +31,7 @@ jobs:
   yaml-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Create docker network
         run: |

--- a/github/workflows/changelog.yaml
+++ b/github/workflows/changelog.yaml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 2
 

--- a/github/workflows/composer.yaml
+++ b/github/workflows/composer.yaml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Create docker network
         run: |
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Create docker network
         run: |
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Create docker network
         run: |

--- a/github/workflows/drupal-module/javascript.yaml
+++ b/github/workflows/drupal-module/javascript.yaml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Create docker network
         run: |

--- a/github/workflows/drupal-module/php.yaml
+++ b/github/workflows/drupal-module/php.yaml
@@ -48,7 +48,7 @@ jobs:
     name: PHP - Check Coding Standards
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Create docker network
         run: |

--- a/github/workflows/drupal-module/styles.yaml
+++ b/github/workflows/drupal-module/styles.yaml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Create docker network
         run: |

--- a/github/workflows/drupal/javascript.yaml
+++ b/github/workflows/drupal/javascript.yaml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Create docker network
         run: |

--- a/github/workflows/drupal/php.yaml
+++ b/github/workflows/drupal/php.yaml
@@ -48,7 +48,7 @@ jobs:
     name: PHP - Check Coding Standards
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Create docker network
         run: |

--- a/github/workflows/drupal/site.yaml
+++ b/github/workflows/drupal/site.yaml
@@ -33,7 +33,7 @@ jobs:
     name: Check that site can be installed
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Create docker network
         run: |
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Install site from our base ref
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.base_ref }}
 
@@ -130,7 +130,7 @@ jobs:
           sudo chmod -Rv a+w web/sites/default || true
 
       # Update site using our updated code.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # Keep our local settings (cf.
           # https://github.com/actions/checkout?tab=readme-ov-file#usage)

--- a/github/workflows/drupal/styles.yaml
+++ b/github/workflows/drupal/styles.yaml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Create docker network
         run: |

--- a/github/workflows/markdown.yaml
+++ b/github/workflows/markdown.yaml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Create docker network
         run: |

--- a/github/workflows/symfony/javascript.yaml
+++ b/github/workflows/symfony/javascript.yaml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Create docker network
         run: |

--- a/github/workflows/symfony/php.yaml
+++ b/github/workflows/symfony/php.yaml
@@ -48,7 +48,7 @@ jobs:
     name: PHP - Check Coding Standards
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Create docker network
         run: |

--- a/github/workflows/symfony/styles.yaml
+++ b/github/workflows/symfony/styles.yaml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Create docker network
         run: |

--- a/github/workflows/twig.yaml
+++ b/github/workflows/twig.yaml
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Create docker network
         run: |

--- a/github/workflows/yaml.yaml
+++ b/github/workflows/yaml.yaml
@@ -31,7 +31,7 @@ jobs:
   yaml-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Create docker network
         run: |


### PR DESCRIPTION
Update to 
* `actions/checkout@v5`
* `go-task/setup-task@v1`

Note:
`go-task/setup-task@v1` seems to set `repo-token` to `GITHUB_TOKEN` as default: https://github.com/go-task/setup-task?tab=readme-ov-file#repo-token