### PR TITLE
Update nginx conf to add custom docker ip range and allow it to be set by env variable

### DIFF
--- a/templates/drupal-10/.docker/nginx.conf
+++ b/templates/drupal-10/.docker/nginx.conf
@@ -17,9 +17,7 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    set_real_ip_from 172.16.0.0/16;
-    real_ip_recursive on;
-    real_ip_header X-Forwarded-For;
+    # Note: set_real_ip_from is only set in the server block to make i configurable
 
     log_format  main  '$http_x_real_ip - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '

--- a/templates/drupal-10/.docker/templates/default.conf.template
+++ b/templates/drupal-10/.docker/templates/default.conf.template
@@ -6,8 +6,8 @@ server {
 
     client_max_body_size ${NGINX_MAX_BODY_SIZE};
 
-    # This also needs to be set in the single server tag and not only in http.
     set_real_ip_from 172.16.0.0/16;
+    set_real_ip_from ${NGINX_SET_REAL_IP_FROM:-192.168.39.0/24};
     real_ip_recursive on;
     real_ip_header X-Forwarded-For;
 

--- a/templates/drupal-11/.docker/nginx.conf
+++ b/templates/drupal-11/.docker/nginx.conf
@@ -17,9 +17,7 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    set_real_ip_from 172.16.0.0/16;
-    real_ip_recursive on;
-    real_ip_header X-Forwarded-For;
+    # Note: set_real_ip_from is only set in the server block to make i configurable
 
     log_format  main  '$http_x_real_ip - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '

--- a/templates/drupal-11/.docker/templates/default.conf.template
+++ b/templates/drupal-11/.docker/templates/default.conf.template
@@ -6,8 +6,8 @@ server {
 
     client_max_body_size ${NGINX_MAX_BODY_SIZE};
 
-    # This also needs to be set in the single server tag and not only in http.
     set_real_ip_from 172.16.0.0/16;
+    set_real_ip_from ${NGINX_SET_REAL_IP_FROM:-192.168.39.0/24};
     real_ip_recursive on;
     real_ip_header X-Forwarded-For;
 

--- a/templates/drupal-7/.docker/nginx.conf
+++ b/templates/drupal-7/.docker/nginx.conf
@@ -17,9 +17,7 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    set_real_ip_from 172.16.0.0/16;
-    real_ip_recursive on;
-    real_ip_header X-Forwarded-For;
+    # Note: set_real_ip_from is only set in the server block to make i configurable
 
     log_format  main  '$http_x_real_ip - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '

--- a/templates/drupal-7/.docker/templates/default.conf.template
+++ b/templates/drupal-7/.docker/templates/default.conf.template
@@ -6,8 +6,8 @@ server {
 
     client_max_body_size ${NGINX_MAX_BODY_SIZE};
 
-    # This also needs to be set in the single server tag and not only in http.
     set_real_ip_from 172.16.0.0/16;
+    set_real_ip_from ${NGINX_SET_REAL_IP_FROM:-192.168.39.0/24};
     real_ip_recursive on;
     real_ip_header X-Forwarded-For;
 

--- a/templates/drupal-8/.docker/nginx.conf
+++ b/templates/drupal-8/.docker/nginx.conf
@@ -17,9 +17,7 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    set_real_ip_from 172.16.0.0/16;
-    real_ip_recursive on;
-    real_ip_header X-Forwarded-For;
+    # Note: set_real_ip_from is only set in the server block to make i configurable
 
     log_format  main  '$http_x_real_ip - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '

--- a/templates/drupal-8/.docker/templates/default.conf.template
+++ b/templates/drupal-8/.docker/templates/default.conf.template
@@ -6,8 +6,8 @@ server {
 
     client_max_body_size ${NGINX_MAX_BODY_SIZE};
 
-    # This also needs to be set in the single server tag and not only in http.
     set_real_ip_from 172.16.0.0/16;
+    set_real_ip_from ${NGINX_SET_REAL_IP_FROM:-192.168.39.0/24};
     real_ip_recursive on;
     real_ip_header X-Forwarded-For;
 

--- a/templates/drupal-9/.docker/nginx.conf
+++ b/templates/drupal-9/.docker/nginx.conf
@@ -17,9 +17,7 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    set_real_ip_from 172.16.0.0/16;
-    real_ip_recursive on;
-    real_ip_header X-Forwarded-For;
+    # Note: set_real_ip_from is only set in the server block to make i configurable
 
     log_format  main  '$http_x_real_ip - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '

--- a/templates/drupal-9/.docker/templates/default.conf.template
+++ b/templates/drupal-9/.docker/templates/default.conf.template
@@ -6,8 +6,8 @@ server {
 
     client_max_body_size ${NGINX_MAX_BODY_SIZE};
 
-    # This also needs to be set in the single server tag and not only in http.
     set_real_ip_from 172.16.0.0/16;
+    set_real_ip_from ${NGINX_SET_REAL_IP_FROM:-192.168.39.0/24};
     real_ip_recursive on;
     real_ip_header X-Forwarded-For;
 

--- a/templates/symfony-3/.docker/nginx.conf
+++ b/templates/symfony-3/.docker/nginx.conf
@@ -17,9 +17,7 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    set_real_ip_from 172.16.0.0/16;
-    real_ip_recursive on;
-    real_ip_header X-Forwarded-For;
+    # Note: set_real_ip_from is only set in the server block to make i configurable
 
     log_format  main  '$http_x_real_ip - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '

--- a/templates/symfony-3/.docker/templates/default.conf.template
+++ b/templates/symfony-3/.docker/templates/default.conf.template
@@ -6,8 +6,8 @@ server {
 
     client_max_body_size ${NGINX_MAX_BODY_SIZE};
 
-    # This also needs to be set in the single server tag and not only in http.
     set_real_ip_from 172.16.0.0/16;
+    set_real_ip_from ${NGINX_SET_REAL_IP_FROM:-192.168.39.0/24};
     real_ip_recursive on;
     real_ip_header X-Forwarded-For;
 

--- a/templates/symfony-4/.docker/nginx.conf
+++ b/templates/symfony-4/.docker/nginx.conf
@@ -17,9 +17,7 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    set_real_ip_from 172.16.0.0/16;
-    real_ip_recursive on;
-    real_ip_header X-Forwarded-For;
+    # Note: set_real_ip_from is only set in the server block to make i configurable
 
     log_format  main  '$http_x_real_ip - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '

--- a/templates/symfony-4/.docker/templates/default.conf.template
+++ b/templates/symfony-4/.docker/templates/default.conf.template
@@ -6,8 +6,8 @@ server {
 
     client_max_body_size ${NGINX_MAX_BODY_SIZE};
 
-    # This also needs to be set in the single server tag and not only in http.
     set_real_ip_from 172.16.0.0/16;
+    set_real_ip_from ${NGINX_SET_REAL_IP_FROM:-192.168.39.0/24};
     real_ip_recursive on;
     real_ip_header X-Forwarded-For;
 

--- a/templates/symfony-6/.docker/nginx.conf
+++ b/templates/symfony-6/.docker/nginx.conf
@@ -17,9 +17,7 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    set_real_ip_from 172.16.0.0/16;
-    real_ip_recursive on;
-    real_ip_header X-Forwarded-For;
+    # Note: set_real_ip_from is only set in the server block to make i configurable
 
     log_format  main  '$http_x_real_ip - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '

--- a/templates/symfony-6/.docker/templates/default.conf.template
+++ b/templates/symfony-6/.docker/templates/default.conf.template
@@ -6,8 +6,8 @@ server {
 
     client_max_body_size ${NGINX_MAX_BODY_SIZE};
 
-    # This also needs to be set in the single server tag and not only in http.
     set_real_ip_from 172.16.0.0/16;
+    set_real_ip_from ${NGINX_SET_REAL_IP_FROM:-192.168.39.0/24};
     real_ip_recursive on;
     real_ip_header X-Forwarded-For;
 

--- a/traefik/traefik.yml
+++ b/traefik/traefik.yml
@@ -2,6 +2,7 @@ api:
   dashboard: true
   insecure: true
   debug: true
+  disableDashboardAd: true
 
 entryPoints:
   http:


### PR DESCRIPTION
https://leantime.itkdev.dk/dashboard/home?tab=ticketdetails#/tickets/showTicket/4868

- Updated nginx templates to include the `192.168.38.0/23` range for `set_real_ip_from`
- Done as `set_real_ip_from ${NGINX_SET_REAL_IP_FROM:-192.168.39.0/24}` to allow for configurability

Have testet on a STG server. Removing `set_real_ip_from` from the `http` block and only having it in the ´server` block doesn't change the behavior. The correct client IP is still logged for requests.

Bonus: `disableDashboardAd: true` should work (@see https://doc.traefik.io/traefik/reference/install-configuration/api-dashboard/#configuration-options)