### PR TITLE
Add actionlint

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -1,0 +1,19 @@
+name: Actions
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - develop
+
+jobs:
+  # https://github.com/rhysd/actionlint/blob/v1.7.10/docs/usage.md#use-actionlint-on-github-actions
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Check workflow files
+        uses: docker://rhysd/actionlint:latest
+        with:
+          args: -color

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -22,13 +22,13 @@ jobs:
       - name: Validate local docker compose files
         run: |
           DC=$(COMPOSE_DOMAIN=test.itkdev.dk docker compose --file templates/${{ matrix.version }}/docker-compose.yml config --quiet 2>&1)
-          [ -z "$DC" ] || { echo $DC; exit 1; }
+          [ -z "$DC" ] || { echo "$DC"; exit 1; }
 
       - name: Validate server docker compose files
         run: |
           DC=$(COMPOSE_SERVER_DOMAIN=test.itkdev.dk docker compose --file templates/${{ matrix.version }}/docker-compose.server.yml config --quiet 2>&1)
-          [ -z "$DC" ] || { echo $DC; exit 1; }
+          [ -z "$DC" ] || { echo "$DC"; exit 1; }
           DC=$(COMPOSE_SERVER_DOMAIN=test.itkdev.dk docker compose --file templates/${{ matrix.version }}/docker-compose.server.yml --file templates/${{ matrix.version }}/docker-compose.dev.yml config --quiet 2>&1)
-          [ -z "$DC" ] || { echo $DC; exit 1; }
+          [ -z "$DC" ] || { echo "$DC"; exit 1; }
           DC=$(COMPOSE_SERVER_DOMAIN=test.itkdev.dk docker compose --file templates/${{ matrix.version }}/docker-compose.server.yml --file templates/${{ matrix.version }}/docker-compose.redirect.yml config --quiet 2>&1)
-          [ -z "$DC" ] || { echo $DC; exit 1; }
+          [ -z "$DC" ] || { echo "$DC"; exit 1; }

--- a/.github/workflows/workflow-template.yaml
+++ b/.github/workflows/workflow-template.yaml
@@ -3,16 +3,18 @@ on: pull_request
 name: Workflow templates
 
 jobs:
-  check-yaml:
+  # https://github.com/rhysd/actionlint/blob/v1.7.10/docs/usage.md#use-actionlint-on-github-actions
+  actionlint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-
-      - run: |
-          docker pull mikefarah/yq
-          for f in $(find github/workflows/ -name '*.yaml'); do
-            docker run --rm --volume "$PWD":/workdir mikefarah/yq "$f" > /dev/null
-          done
+      - name: Check workflow files
+        # uses: docker://rhysd/actionlint:latest
+        # with:
+        #   args: -color github/workflows/*.yaml github/workflows/*/*.yaml
+        # @todo Can we make globbing work in `with.args`?
+        run: |
+          docker run --rm --volume "$PWD":/repo --workdir /repo rhysd/actionlint:latest -color github/workflows/*.yaml github/workflows/*/*.yaml
 
   shellcheck:
     runs-on: ubuntu-latest

--- a/github/workflows/drupal/site.yaml
+++ b/github/workflows/drupal/site.yaml
@@ -48,12 +48,15 @@ jobs:
           docker compose exec phpfpm composer install --no-interaction
 
       - name: Install site
+        # https://docs.github.com/en/actions/reference/security/secure-use#good-practices-for-mitigating-script-injection-attacks
+        env:
+          HASH_SALT: ${{ github.head_ref }}
         run: |
           # Add some local settings.
-          cat > web/sites/default/settings.local.php <<'EOF'
+          cat > web/sites/default/settings.local.php <<EOF
           <?php
 
-          $settings['hash_salt'] = '${{ github.head_ref }}';
+          \$settings['hash_salt'] = '$HASH_SALT';
           EOF
 
           # Install the site from config
@@ -61,7 +64,7 @@ jobs:
 
       - name: Show site URL
         run: |
-          echo $(docker compose exec phpfpm vendor/bin/drush --uri=http://$(docker compose port nginx 8080) user:login)
+          docker compose exec phpfpm vendor/bin/drush --uri="http://$(docker compose port nginx 8080)" user:login
 
   update-site:
     # Check updating site only on pull request.
@@ -109,12 +112,14 @@ jobs:
           docker compose exec phpfpm composer install --no-interaction
 
       - name: Install site
+        env:
+          HASH_SALT: ${{ github.head_ref }}
         run: |
           # Add some local settings.
-          cat > web/sites/default/settings.local.php <<'EOF'
+          cat > web/sites/default/settings.local.php <<EOF
           <?php
 
-          $settings['hash_salt'] = '${{ github.head_ref }}';
+          \$settings['hash_salt'] = '$HASH_SALT';
           EOF
 
           # Install the site from config
@@ -122,11 +127,11 @@ jobs:
 
       - name: Show site URL
         run: |
-          echo $(docker compose exec phpfpm vendor/bin/drush --uri=http://$(docker compose port nginx 8080) user:login)
+          docker compose exec phpfpm vendor/bin/drush --uri="http://$(docker compose port nginx 8080)" user:login
 
       - name: Clean up root stuff
         run: |
-          sudo chown -Rv $USER:$USER vendor/ web/ private-files/ || true
+          sudo chown -Rv "$USER:$USER" vendor/ web/ private-files/ || true
           sudo chmod -Rv a+w web/sites/default || true
 
       # Update site using our updated code.
@@ -150,4 +155,4 @@ jobs:
 
       - name: Show site URL
         run: |
-          echo $(docker compose exec phpfpm vendor/bin/drush --uri=http://$(docker compose port nginx 8080) user:login)
+          docker compose exec phpfpm vendor/bin/drush --uri="http://$(docker compose port nginx 8080)" user:login


### PR DESCRIPTION
Adds [actionlint](https://github.com/rhysd/actionlint) to the mix and cleans up actions (including template actions).

> [!TIP]
> Protip: Run `docker run --rm --volume "$PWD":/repo --workdir /repo rhysd/actionlint:latest -color` locally to check files (see https://github.com/rhysd/actionlint/blob/v1.7.10/docs/usage.md#docker-image for details and other options).

