### PR TITLE
Fix nginx set_real_ip_from conf

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -21,16 +21,16 @@ jobs:
 
       - name: Validate local docker compose files
         run: |
-          DC=$(COMPOSE_DOMAIN=test.itkdev.dk docker compose --file templates/${{ matrix.version }}/docker-compose.yml config --quiet 2>&1)
+          DC=$(COMPOSE_DOMAIN=example.org docker compose --file templates/${{ matrix.version }}/docker-compose.yml config --quiet 2>&1)
           [ -z "$DC" ] || { echo $DC; exit 1; }
 
       - name: Validate server docker compose files
         run: |
-          DC=$(COMPOSE_SERVER_DOMAIN=test.itkdev.dk docker compose --file templates/${{ matrix.version }}/docker-compose.server.yml config --quiet 2>&1)
+          DC=$(COMPOSE_SERVER_DOMAIN=example.org docker compose --file templates/${{ matrix.version }}/docker-compose.server.yml config --quiet 2>&1)
           [ -z "$DC" ] || { echo $DC; exit 1; }
-          DC=$(COMPOSE_SERVER_DOMAIN=test.itkdev.dk docker compose --file templates/${{ matrix.version }}/docker-compose.server.yml --file templates/${{ matrix.version }}/docker-compose.dev.yml config --quiet 2>&1)
+          DC=$(COMPOSE_SERVER_DOMAIN=example.org docker compose --file templates/${{ matrix.version }}/docker-compose.server.yml --file templates/${{ matrix.version }}/docker-compose.dev.yml config --quiet 2>&1)
           [ -z "$DC" ] || { echo $DC; exit 1; }
-          DC=$(COMPOSE_SERVER_DOMAIN=test.itkdev.dk docker compose --file templates/${{ matrix.version }}/docker-compose.server.yml --file templates/${{ matrix.version }}/docker-compose.redirect.yml config --quiet 2>&1)
+          DC=$(COMPOSE_SERVER_DOMAIN=example.org docker compose --file templates/${{ matrix.version }}/docker-compose.server.yml --file templates/${{ matrix.version }}/docker-compose.redirect.yml config --quiet 2>&1)
           [ -z "$DC" ] || { echo $DC; exit 1; }
 
   validate-nginx-conf:
@@ -53,4 +53,4 @@ jobs:
 
       - name: Validate nginx conf
         run: |
-          COMPOSE_DOMAIN=test.itkdev.dk docker compose --file templates/${{ matrix.version }}/${{ matrix.compose_file}} run --rm nginx nginx -t
+          COMPOSE_DOMAIN=example.org docker compose --file templates/${{ matrix.version }}/${{ matrix.compose_file}} run --rm nginx nginx -t

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version:
+        version: &template_version
           - drupal-7
           - drupal-8
           - drupal-9
@@ -32,3 +32,25 @@ jobs:
           [ -z "$DC" ] || { echo $DC; exit 1; }
           DC=$(COMPOSE_SERVER_DOMAIN=test.itkdev.dk docker compose --file templates/${{ matrix.version }}/docker-compose.server.yml --file templates/${{ matrix.version }}/docker-compose.redirect.yml config --quiet 2>&1)
           [ -z "$DC" ] || { echo $DC; exit 1; }
+
+  validate-nginx-conf:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version: *template_version
+        compose_file:
+          - docker-compose.yml
+          - docker-compose.server.yml
+
+    name: Validate nginx conf (${{ matrix.version }}/${{ matrix.compose_file}})
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Create docker network
+        run: |
+          docker network create frontend
+
+      - name: Validate nginx conf
+        run: |
+          COMPOSE_DOMAIN=test.itkdev.dk docker compose --file templates/${{ matrix.version }}/${{ matrix.compose_file}} run --rm nginx nginx -t

--- a/templates/drupal-10/.docker/nginx.conf
+++ b/templates/drupal-10/.docker/nginx.conf
@@ -17,7 +17,7 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    # Note: set_real_ip_from is only set in the server block to make i configurable
+    # Note: set_real_ip_from is set in the server block
 
     log_format  main  '$http_x_real_ip - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '

--- a/templates/drupal-10/.docker/templates/default.conf.template
+++ b/templates/drupal-10/.docker/templates/default.conf.template
@@ -7,7 +7,7 @@ server {
     client_max_body_size ${NGINX_MAX_BODY_SIZE};
 
     set_real_ip_from 172.16.0.0/16;
-    set_real_ip_from ${NGINX_SET_REAL_IP_FROM:-192.168.39.0/24};
+    set_real_ip_from 192.168.39.0/24;
     real_ip_recursive on;
     real_ip_header X-Forwarded-For;
 

--- a/templates/drupal-11/.docker/nginx.conf
+++ b/templates/drupal-11/.docker/nginx.conf
@@ -17,7 +17,7 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    # Note: set_real_ip_from is only set in the server block to make i configurable
+    # Note: set_real_ip_from is set in the server block
 
     log_format  main  '$http_x_real_ip - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '

--- a/templates/drupal-11/.docker/templates/default.conf.template
+++ b/templates/drupal-11/.docker/templates/default.conf.template
@@ -7,7 +7,7 @@ server {
     client_max_body_size ${NGINX_MAX_BODY_SIZE};
 
     set_real_ip_from 172.16.0.0/16;
-    set_real_ip_from ${NGINX_SET_REAL_IP_FROM:-192.168.39.0/24};
+    set_real_ip_from 192.168.39.0/24;
     real_ip_recursive on;
     real_ip_header X-Forwarded-For;
 

--- a/templates/drupal-7/.docker/nginx.conf
+++ b/templates/drupal-7/.docker/nginx.conf
@@ -17,7 +17,7 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    # Note: set_real_ip_from is only set in the server block to make i configurable
+    # Note: set_real_ip_from is set in the server block
 
     log_format  main  '$http_x_real_ip - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '

--- a/templates/drupal-7/.docker/templates/default.conf.template
+++ b/templates/drupal-7/.docker/templates/default.conf.template
@@ -7,7 +7,7 @@ server {
     client_max_body_size ${NGINX_MAX_BODY_SIZE};
 
     set_real_ip_from 172.16.0.0/16;
-    set_real_ip_from ${NGINX_SET_REAL_IP_FROM:-192.168.39.0/24};
+    set_real_ip_from 192.168.39.0/24;
     real_ip_recursive on;
     real_ip_header X-Forwarded-For;
 

--- a/templates/drupal-7/docker-compose.yml
+++ b/templates/drupal-7/docker-compose.yml
@@ -79,7 +79,7 @@ services:
       # - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
 
   memcached:
-    image: "memcached:latest"
+    image: memcached:alpine
     networks:
       - app
     ports:

--- a/templates/drupal-8/.docker/nginx.conf
+++ b/templates/drupal-8/.docker/nginx.conf
@@ -17,7 +17,7 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    # Note: set_real_ip_from is only set in the server block to make i configurable
+    # Note: set_real_ip_from is set in the server block
 
     log_format  main  '$http_x_real_ip - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '

--- a/templates/drupal-8/.docker/templates/default.conf.template
+++ b/templates/drupal-8/.docker/templates/default.conf.template
@@ -7,7 +7,7 @@ server {
     client_max_body_size ${NGINX_MAX_BODY_SIZE};
 
     set_real_ip_from 172.16.0.0/16;
-    set_real_ip_from ${NGINX_SET_REAL_IP_FROM:-192.168.39.0/24};
+    set_real_ip_from 192.168.39.0/24;
     real_ip_recursive on;
     real_ip_header X-Forwarded-For;
 

--- a/templates/drupal-8/docker-compose.yml
+++ b/templates/drupal-8/docker-compose.yml
@@ -78,7 +78,7 @@ services:
       # - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
 
   memcached:
-    image: "memcached:latest"
+    image: memcached:alpine
     networks:
       - app
     ports:

--- a/templates/drupal-9/.docker/nginx.conf
+++ b/templates/drupal-9/.docker/nginx.conf
@@ -17,7 +17,7 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    # Note: set_real_ip_from is only set in the server block to make i configurable
+    # Note: set_real_ip_from is set in the server block
 
     log_format  main  '$http_x_real_ip - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '

--- a/templates/drupal-9/.docker/templates/default.conf.template
+++ b/templates/drupal-9/.docker/templates/default.conf.template
@@ -7,7 +7,7 @@ server {
     client_max_body_size ${NGINX_MAX_BODY_SIZE};
 
     set_real_ip_from 172.16.0.0/16;
-    set_real_ip_from ${NGINX_SET_REAL_IP_FROM:-192.168.39.0/24};
+    set_real_ip_from 192.168.39.0/24;
     real_ip_recursive on;
     real_ip_header X-Forwarded-For;
 

--- a/templates/drupal-9/docker-compose.server.yml
+++ b/templates/drupal-9/docker-compose.server.yml
@@ -1,4 +1,4 @@
-# itk-version: 3.2.2
+# itk-version: 3.2.4
 networks:
   frontend:
     external: true

--- a/templates/drupal-9/docker-compose.yml
+++ b/templates/drupal-9/docker-compose.yml
@@ -80,7 +80,7 @@ services:
       # - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
 
   memcached:
-    image: "memcached:latest"
+    image: memcached:alpine
     networks:
       - app
     ports:

--- a/templates/symfony-3/.docker/nginx.conf
+++ b/templates/symfony-3/.docker/nginx.conf
@@ -17,7 +17,7 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    # Note: set_real_ip_from is only set in the server block to make i configurable
+    # Note: set_real_ip_from is set in the server block
 
     log_format  main  '$http_x_real_ip - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '

--- a/templates/symfony-3/.docker/templates/default.conf.template
+++ b/templates/symfony-3/.docker/templates/default.conf.template
@@ -7,7 +7,7 @@ server {
     client_max_body_size ${NGINX_MAX_BODY_SIZE};
 
     set_real_ip_from 172.16.0.0/16;
-    set_real_ip_from ${NGINX_SET_REAL_IP_FROM:-192.168.39.0/24};
+    set_real_ip_from 192.168.39.0/24;
     real_ip_recursive on;
     real_ip_header X-Forwarded-For;
 

--- a/templates/symfony-4/.docker/nginx.conf
+++ b/templates/symfony-4/.docker/nginx.conf
@@ -17,7 +17,7 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    # Note: set_real_ip_from is only set in the server block to make i configurable
+    # Note: set_real_ip_from is set in the server block
 
     log_format  main  '$http_x_real_ip - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '

--- a/templates/symfony-4/.docker/templates/default.conf.template
+++ b/templates/symfony-4/.docker/templates/default.conf.template
@@ -7,7 +7,7 @@ server {
     client_max_body_size ${NGINX_MAX_BODY_SIZE};
 
     set_real_ip_from 172.16.0.0/16;
-    set_real_ip_from ${NGINX_SET_REAL_IP_FROM:-192.168.39.0/24};
+    set_real_ip_from 192.168.39.0/24;
     real_ip_recursive on;
     real_ip_header X-Forwarded-For;
 

--- a/templates/symfony-6/.docker/nginx.conf
+++ b/templates/symfony-6/.docker/nginx.conf
@@ -17,7 +17,7 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    # Note: set_real_ip_from is only set in the server block to make i configurable
+    # Note: set_real_ip_from is set in the server block
 
     log_format  main  '$http_x_real_ip - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '

--- a/templates/symfony-6/.docker/templates/default.conf.template
+++ b/templates/symfony-6/.docker/templates/default.conf.template
@@ -7,7 +7,7 @@ server {
     client_max_body_size ${NGINX_MAX_BODY_SIZE};
 
     set_real_ip_from 172.16.0.0/16;
-    set_real_ip_from ${NGINX_SET_REAL_IP_FROM:-192.168.39.0/24};
+    set_real_ip_from 192.168.39.0/24;
     real_ip_recursive on;
     real_ip_header X-Forwarded-For;
 


### PR DESCRIPTION
https://leantime.itkdev.dk/_#/tickets/showTicket/6275

* Replaces `"${NGINX_SET_REAL_IP_FROM:-192.168.39.0/24}"` with `192.168.39.0/24` in nginx conf templates. See below for details on why.
* Adds simple nginx conf validation

# The details

Using `${name:-…}` to set a default value for a non-existing (or empty) environment variable does not work in nginx templates:

``` shell
$ (cd templates/symfony-6; COMPOSE_DOMAIN=example.com docker compose run --no-deps --rm nginx nginx -t)
…
2026/01/07 11:58:37 [emerg] 1#1: host not found in set_real_ip_from "${NGINX_SET_REAL_IP_FROM:-192.168.39.0/24}" in /etc/nginx/conf.d/default.conf:10
nginx: [emerg] host not found in set_real_ip_from "${NGINX_SET_REAL_IP_FROM:-192.168.39.0/24}" in /etc/nginx/conf.d/default.conf:10
nginx: configuration file /etc/nginx/nginx.conf test failed
```

Notice `"${NGINX_SET_REAL_IP_FROM:-192.168.39.0/24}"` is reported, i.e. `${NGINX_SET_REAL_IP_FROM:-192.168.39.0/24}` **is not** replaced with `192.168.39.0/24` as hoped (and expected due to it working in many other places).

It's the nginx docker image that substitutes variables in templates using `envsubst`, cf. https://github.com/docker-library/docs/tree/master/nginx#using-environment-variables-in-nginx-configuration-new-in-119, but `envsubst` does not support default values for non-existing variables:

``` shell
$ (cd templates/symfony-6; COMPOSE_DOMAIN=example.com docker compose run --no-deps --rm nginx sh -c 'envsubst < /etc/nginx/templates/default.conf.template')
server {
    listen 8080;
    server_name localhost;

    root /app/public;

    client_max_body_size 5M;

    set_real_ip_from 172.16.0.0/16;
    set_real_ip_from ${NGINX_SET_REAL_IP_FROM:-192.168.39.0/24};
…
```
 