### PR TITLE
Added support for cron metrics export in nginx

### DIFF
--- a/templates/drupal-10/.docker/templates/default.conf.template
+++ b/templates/drupal-10/.docker/templates/default.conf.template
@@ -11,6 +11,15 @@ server {
     real_ip_recursive on;
     real_ip_header X-Forwarded-For;
 
+    location = /cron-metrics {
+        # Proxy to supercronic metrics
+        proxy_pass http://${NGINX_CRON_METRICS}/metrics;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location = /favicon.ico {
         log_not_found off;
         access_log off;

--- a/templates/drupal-10/docker-compose.server.yml
+++ b/templates/drupal-10/docker-compose.server.yml
@@ -38,6 +38,7 @@ services:
       - .:/app
     environment:
       NGINX_FPM_SERVICE: ${COMPOSE_PROJECT_NAME}-phpfpm-1:9000
+      NGINX_CRON_METRICS: ${COMPOSE_PROJECT_NAME}-phpfpm-1:9746
       NGINX_WEB_ROOT: /app/web
       NGINX_PORT: 8080
       NGINX_MAX_BODY_SIZE: 5M
@@ -50,6 +51,9 @@ services:
       - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.rule=Host(`${COMPOSE_SERVER_DOMAIN}`)"
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.entrypoints=websecure"
+      # Cron-metrics protection.
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-metrics.rule=Host(`${COMPOSE_DOMAIN}`) && PathPrefix(`/cron-metrics`) "
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-metrics.middlewares=ITKMetricsAuth@file"
 
   memcached:
     image: "memcached:latest"

--- a/templates/drupal-10/docker-compose.yml
+++ b/templates/drupal-10/docker-compose.yml
@@ -68,6 +68,7 @@ services:
       - .:/app
     environment:
       NGINX_FPM_SERVICE: ${COMPOSE_PROJECT_NAME}-phpfpm-1:9000
+      NGINX_CRON_METRICS: ${COMPOSE_PROJECT_NAME}-phpfpm-1:9746
       NGINX_WEB_ROOT: /app/web
       NGINX_PORT: 8080
       NGINX_MAX_BODY_SIZE: 5M
@@ -78,6 +79,9 @@ services:
       # HTTPS config - uncomment to enable redirect from :80 to :443
       # - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.middlewares=redirect-to-https"
       # - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
+      # Cron-metrics protection (metrics:metrics for local testing).
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-metrics.rule=Host(`${COMPOSE_DOMAIN}`) && PathPrefix(`/cron-metrics`) "
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-metrics.middlewares=ITKMetricsAuth@file"
 
   memcached:
     image: memcached:alpine

--- a/templates/drupal-11/.docker/templates/default.conf.template
+++ b/templates/drupal-11/.docker/templates/default.conf.template
@@ -11,6 +11,15 @@ server {
     real_ip_recursive on;
     real_ip_header X-Forwarded-For;
 
+    location = /cron-metrics {
+        # Proxy to supercronic metrics
+        proxy_pass http://${NGINX_CRON_METRICS}/metrics;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location = /favicon.ico {
         log_not_found off;
         access_log off;

--- a/templates/drupal-11/docker-compose.server.yml
+++ b/templates/drupal-11/docker-compose.server.yml
@@ -38,6 +38,7 @@ services:
       - .:/app
     environment:
       NGINX_FPM_SERVICE: ${COMPOSE_PROJECT_NAME}-phpfpm-1:9000
+      NGINX_CRON_METRICS: ${COMPOSE_PROJECT_NAME}-phpfpm-1:9746
       NGINX_WEB_ROOT: /app/web
       NGINX_PORT: 8080
       NGINX_MAX_BODY_SIZE: 5M
@@ -50,6 +51,9 @@ services:
       - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.rule=Host(`${COMPOSE_SERVER_DOMAIN}`)"
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.entrypoints=websecure"
+      # Cron-metrics protection.
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-metrics.rule=Host(`${COMPOSE_DOMAIN}`) && PathPrefix(`/cron-metrics`) "
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-metrics.middlewares=ITKMetricsAuth@file"
 
   memcached:
     image: "memcached:latest"

--- a/templates/drupal-11/docker-compose.yml
+++ b/templates/drupal-11/docker-compose.yml
@@ -65,6 +65,7 @@ services:
       - .:/app
     environment:
       NGINX_FPM_SERVICE: ${COMPOSE_PROJECT_NAME}-phpfpm-1:9000
+      NGINX_CRON_METRICS: ${COMPOSE_PROJECT_NAME}-phpfpm-1:9746
       NGINX_WEB_ROOT: /app/web
       NGINX_PORT: 8080
       NGINX_MAX_BODY_SIZE: 5M
@@ -75,6 +76,9 @@ services:
       # HTTPS config - enable redirect from :80 to :443
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.middlewares=redirect-to-https"
       - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
+      # Cron-metrics protection.
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-metrics.rule=Host(`${COMPOSE_DOMAIN}`) && PathPrefix(`/cron-metrics`) "
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-metrics.middlewares=ITKMetricsAuth@file"
 
   memcached:
     image: memcached:alpine

--- a/templates/drupal-7/.docker/templates/default.conf.template
+++ b/templates/drupal-7/.docker/templates/default.conf.template
@@ -11,6 +11,15 @@ server {
     real_ip_recursive on;
     real_ip_header X-Forwarded-For;
 
+    location = /cron-metrics {
+        # Proxy to supercronic metrics
+        proxy_pass http://${NGINX_CRON_METRICS}/metrics;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location = /favicon.ico {
         log_not_found off;
         access_log off;

--- a/templates/drupal-7/docker-compose.server.yml
+++ b/templates/drupal-7/docker-compose.server.yml
@@ -37,6 +37,7 @@ services:
       - .:/app
     environment:
       NGINX_FPM_SERVICE: ${COMPOSE_PROJECT_NAME}-phpfpm-1:9000
+      NGINX_CRON_METRICS: ${COMPOSE_PROJECT_NAME}-phpfpm-1:9746
       NGINX_WEB_ROOT: /app
       NGINX_PORT: 8080
       NGINX_MAX_BODY_SIZE: 5M
@@ -49,6 +50,9 @@ services:
       - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.rule=Host(`${COMPOSE_SERVER_DOMAIN}`)"
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.entrypoints=websecure"
+      # Cron-metrics protection.
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-metrics.rule=Host(`${COMPOSE_DOMAIN}`) && PathPrefix(`/cron-metrics`) "
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-metrics.middlewares=ITKMetricsAuth@file"
 
   memcached:
     image: "memcached:latest"

--- a/templates/drupal-7/docker-compose.yml
+++ b/templates/drupal-7/docker-compose.yml
@@ -67,6 +67,7 @@ services:
       - .:/app
     environment:
       NGINX_FPM_SERVICE: ${COMPOSE_PROJECT_NAME}-phpfpm-1:9000
+      NGINX_CRON_METRICS: ${COMPOSE_PROJECT_NAME}-phpfpm-1:9746
       NGINX_WEB_ROOT: /app
       NGINX_PORT: 8080
       NGINX_MAX_BODY_SIZE: 5M
@@ -77,6 +78,9 @@ services:
       # HTTPS config - uncomment to enable redirect from :80 to :443
       # - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.middlewares=redirect-to-https"
       # - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
+      # Cron-metrics protection.
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-metrics.rule=Host(`${COMPOSE_DOMAIN}`) && PathPrefix(`/cron-metrics`) "
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-metrics.middlewares=ITKMetricsAuth@file"
 
   memcached:
     image: "memcached:latest"

--- a/templates/drupal-8/.docker/templates/default.conf.template
+++ b/templates/drupal-8/.docker/templates/default.conf.template
@@ -11,6 +11,15 @@ server {
     real_ip_recursive on;
     real_ip_header X-Forwarded-For;
 
+    location = /cron-metrics {
+        # Proxy to supercronic metrics
+        proxy_pass http://${NGINX_CRON_METRICS}/metrics;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location = /favicon.ico {
         log_not_found off;
         access_log off;

--- a/templates/drupal-8/docker-compose.server.yml
+++ b/templates/drupal-8/docker-compose.server.yml
@@ -36,6 +36,7 @@ services:
       - .:/app
     environment:
       NGINX_FPM_SERVICE: ${COMPOSE_PROJECT_NAME}-phpfpm-1:9000
+      NGINX_CRON_METRICS: ${COMPOSE_PROJECT_NAME}-phpfpm-1:9746
       NGINX_WEB_ROOT: /app/web
       NGINX_PORT: 8080
       NGINX_MAX_BODY_SIZE: 5M
@@ -48,6 +49,9 @@ services:
       - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.rule=Host(`${COMPOSE_SERVER_DOMAIN}`)"
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.entrypoints=websecure"
+      # Cron-metrics protection.
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-metrics.rule=Host(`${COMPOSE_DOMAIN}`) && PathPrefix(`/cron-metrics`) "
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-metrics.middlewares=ITKMetricsAuth@file"
 
   memcached:
     image: "memcached:latest"

--- a/templates/drupal-8/docker-compose.yml
+++ b/templates/drupal-8/docker-compose.yml
@@ -66,6 +66,7 @@ services:
       - .:/app
     environment:
       NGINX_FPM_SERVICE: ${COMPOSE_PROJECT_NAME}-phpfpm-1:9000
+      NGINX_CRON_METRICS: ${COMPOSE_PROJECT_NAME}-phpfpm-1:9746
       NGINX_WEB_ROOT: /app/web
       NGINX_PORT: 8080
       NGINX_MAX_BODY_SIZE: 5M
@@ -76,6 +77,9 @@ services:
       # HTTPS config - uncomment to enable redirect from :80 to :443
       # - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.middlewares=redirect-to-https"
       # - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
+      # Cron-metrics protection.
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-metrics.rule=Host(`${COMPOSE_DOMAIN}`) && PathPrefix(`/cron-metrics`) "
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-metrics.middlewares=ITKMetricsAuth@file"
 
   memcached:
     image: "memcached:latest"

--- a/templates/drupal-9/.docker/templates/default.conf.template
+++ b/templates/drupal-9/.docker/templates/default.conf.template
@@ -11,6 +11,15 @@ server {
     real_ip_recursive on;
     real_ip_header X-Forwarded-For;
 
+    location = /cron-metrics {
+        # Proxy to supercronic metrics
+        proxy_pass http://${NGINX_CRON_METRICS}/metrics;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location = /favicon.ico {
         log_not_found off;
         access_log off;

--- a/templates/drupal-9/docker-compose.server.yml
+++ b/templates/drupal-9/docker-compose.server.yml
@@ -38,6 +38,7 @@ services:
       - .:/app
     environment:
       NGINX_FPM_SERVICE: ${COMPOSE_PROJECT_NAME}-phpfpm-1:9000
+      NGINX_CRON_METRICS: ${COMPOSE_PROJECT_NAME}-phpfpm-1:9746
       NGINX_WEB_ROOT: /app/web
       NGINX_PORT: 8080
       NGINX_MAX_BODY_SIZE: 5M
@@ -50,6 +51,9 @@ services:
       - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.rule=Host(`${COMPOSE_SERVER_DOMAIN}`)"
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.entrypoints=websecure"
+      # Cron-metrics protection.
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-metrics.rule=Host(`${COMPOSE_DOMAIN}`) && PathPrefix(`/cron-metrics`) "
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-metrics.middlewares=ITKMetricsAuth@file"
 
   memcached:
     image: "memcached:latest"

--- a/templates/drupal-9/docker-compose.yml
+++ b/templates/drupal-9/docker-compose.yml
@@ -68,6 +68,7 @@ services:
       - .:/app
     environment:
       NGINX_FPM_SERVICE: ${COMPOSE_PROJECT_NAME}-phpfpm-1:9000
+      NGINX_CRON_METRICS: ${COMPOSE_PROJECT_NAME}-phpfpm-1:9746
       NGINX_WEB_ROOT: /app/web
       NGINX_PORT: 8080
       NGINX_MAX_BODY_SIZE: 5M
@@ -78,6 +79,9 @@ services:
       # HTTPS config - uncomment to enable redirect from :80 to :443
       # - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.middlewares=redirect-to-https"
       # - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
+      # Cron-metrics protection.
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-metrics.rule=Host(`${COMPOSE_DOMAIN}`) && PathPrefix(`/cron-metrics`) "
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-metrics.middlewares=ITKMetricsAuth@file"
 
   memcached:
     image: "memcached:latest"

--- a/templates/symfony-3/.docker/templates/default.conf.template
+++ b/templates/symfony-3/.docker/templates/default.conf.template
@@ -11,6 +11,15 @@ server {
     real_ip_recursive on;
     real_ip_header X-Forwarded-For;
 
+    location = /cron-metrics {
+        # Proxy to supercronic metrics
+        proxy_pass http://${NGINX_CRON_METRICS}/metrics;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location / {
         # try to serve file directly, fallback to app.php
         #try_files $uri /app.php$is_args$args;

--- a/templates/symfony-3/docker-compose.server.yml
+++ b/templates/symfony-3/docker-compose.server.yml
@@ -34,6 +34,7 @@ services:
       - .:/app
     environment:
       NGINX_FPM_SERVICE: ${COMPOSE_PROJECT_NAME}-phpfpm-1:9000
+      NGINX_CRON_METRICS: ${COMPOSE_PROJECT_NAME}-phpfpm-1:9746
       NGINX_WEB_ROOT: /app/web
       NGINX_PORT: 8080
       NGINX_MAX_BODY_SIZE: 5M
@@ -46,3 +47,6 @@ services:
       - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.rule=Host(`${COMPOSE_SERVER_DOMAIN}`)"
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.entrypoints=websecure"
+      # Cron-metrics protection.
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-metrics.rule=Host(`${COMPOSE_DOMAIN}`) && PathPrefix(`/cron-metrics`) "
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-metrics.middlewares=ITKMetricsAuth@file"

--- a/templates/symfony-3/docker-compose.yml
+++ b/templates/symfony-3/docker-compose.yml
@@ -64,6 +64,7 @@ services:
       - .:/app
     environment:
       NGINX_FPM_SERVICE: ${COMPOSE_PROJECT_NAME}-phpfpm-1:9000
+      NGINX_CRON_METRICS: ${COMPOSE_PROJECT_NAME}-phpfpm-1:9746
       NGINX_WEB_ROOT: /app/web
       NGINX_PORT: 8080
       NGINX_MAX_BODY_SIZE: 5M
@@ -74,6 +75,9 @@ services:
       # HTTPS config - uncomment to enable redirect from :80 to :443
       # - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.middlewares=redirect-to-https"
       # - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
+      # Cron-metrics protection.
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-metrics.rule=Host(`${COMPOSE_DOMAIN}`) && PathPrefix(`/cron-metrics`) "
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-metrics.middlewares=ITKMetricsAuth@file"
 
   mail:
     image: axllent/mailpit

--- a/templates/symfony-4/.docker/templates/default.conf.template
+++ b/templates/symfony-4/.docker/templates/default.conf.template
@@ -11,6 +11,15 @@ server {
     real_ip_recursive on;
     real_ip_header X-Forwarded-For;
 
+    location = /cron-metrics {
+        # Proxy to supercronic metrics
+        proxy_pass http://${NGINX_CRON_METRICS}/metrics;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location / {
         # try to serve file directly, fallback to index.php
         try_files $uri /index.php$is_args$args;

--- a/templates/symfony-4/docker-compose.server.yml
+++ b/templates/symfony-4/docker-compose.server.yml
@@ -34,6 +34,7 @@ services:
       - .:/app
     environment:
       NGINX_FPM_SERVICE: ${COMPOSE_PROJECT_NAME}-phpfpm-1:9000
+      NGINX_CRON_METRICS: ${COMPOSE_PROJECT_NAME}-phpfpm-1:9746
       NGINX_WEB_ROOT: /app/public
       NGINX_PORT: 8080
       NGINX_MAX_BODY_SIZE: 5M
@@ -46,3 +47,6 @@ services:
       - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.rule=Host(`${COMPOSE_SERVER_DOMAIN}`)"
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.entrypoints=websecure"
+      # Cron-metrics protection.
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-metrics.rule=Host(`${COMPOSE_DOMAIN}`) && PathPrefix(`/cron-metrics`) "
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-metrics.middlewares=ITKMetricsAuth@file"

--- a/templates/symfony-4/docker-compose.yml
+++ b/templates/symfony-4/docker-compose.yml
@@ -64,6 +64,7 @@ services:
       - .:/app
     environment:
       NGINX_FPM_SERVICE: ${COMPOSE_PROJECT_NAME}-phpfpm-1:9000
+      NGINX_CRON_METRICS: ${COMPOSE_PROJECT_NAME}-phpfpm-1:9746
       NGINX_WEB_ROOT: /app/public
       NGINX_PORT: 8080
       NGINX_MAX_BODY_SIZE: 5M
@@ -74,6 +75,9 @@ services:
       # HTTPS config - uncomment to enable redirect from :80 to :443
       # - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.middlewares=redirect-to-https"
       # - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
+      # Cron-metrics protection.
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-metrics.rule=Host(`${COMPOSE_DOMAIN}`) && PathPrefix(`/cron-metrics`) "
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-metrics.middlewares=ITKMetricsAuth@file"
 
   mail:
     image: axllent/mailpit

--- a/templates/symfony-6/.docker/templates/default.conf.template
+++ b/templates/symfony-6/.docker/templates/default.conf.template
@@ -11,6 +11,15 @@ server {
     real_ip_recursive on;
     real_ip_header X-Forwarded-For;
 
+    location = /cron-metrics {
+        # Proxy to supercronic metrics
+        proxy_pass http://${NGINX_CRON_METRICS}/metrics;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location / {
         # try to serve file directly, fallback to index.php
         try_files $uri /index.php$is_args$args;

--- a/templates/symfony-6/docker-compose.server.yml
+++ b/templates/symfony-6/docker-compose.server.yml
@@ -34,6 +34,7 @@ services:
       - .:/app
     environment:
       NGINX_FPM_SERVICE: ${COMPOSE_PROJECT_NAME}-phpfpm-1:9000
+      NGINX_CRON_METRICS: ${COMPOSE_PROJECT_NAME}-phpfpm-1:9746
       NGINX_WEB_ROOT: /app/public
       NGINX_PORT: 8080
       NGINX_MAX_BODY_SIZE: 5M
@@ -46,3 +47,6 @@ services:
       - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.rule=Host(`${COMPOSE_SERVER_DOMAIN}`)"
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.entrypoints=websecure"
+      # Cron-metrics protection.
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-metrics.rule=Host(`${COMPOSE_DOMAIN}`) && PathPrefix(`/cron-metrics`) "
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-metrics.middlewares=ITKMetricsAuth@file"

--- a/templates/symfony-6/docker-compose.yml
+++ b/templates/symfony-6/docker-compose.yml
@@ -61,6 +61,7 @@ services:
       - .:/app
     environment:
       NGINX_FPM_SERVICE: ${COMPOSE_PROJECT_NAME}-phpfpm-1:9000
+      NGINX_CRON_METRICS: ${COMPOSE_PROJECT_NAME}-phpfpm-1:9746
       NGINX_WEB_ROOT: /app/public
       NGINX_PORT: 8080
       NGINX_MAX_BODY_SIZE: 5M
@@ -71,6 +72,9 @@ services:
       # HTTPS config - uncomment to enable redirect from :80 to :443
       # - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.middlewares=redirect-to-https"
       # - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
+      # Cron-metrics protection.
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-metrics.rule=Host(`${COMPOSE_DOMAIN}`) && PathPrefix(`/cron-metrics`) "
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-metrics.middlewares=ITKMetricsAuth@file"
 
   mail:
     image: axllent/mailpit


### PR DESCRIPTION
Validation error is not related to this PR: 

> time="2026-01-09T13:00:01Z" level=warning msg="The \"COMPOSE_DOMAIN\" variable is not set. Defaulting to a blank string."