### PR TITLE
Add php to drush call

### DIFF
--- a/scripts/itkdev-docker-compose
+++ b/scripts/itkdev-docker-compose
@@ -829,7 +829,7 @@ EOF
       root=/app/web
     fi
     if [ -e $docker_compose_dir/vendor/bin/drush ]; then
-      docker_compose exec phpfpm /app/vendor/bin/drush --root=$root "$@"
+      docker_compose exec phpfpm php /app/vendor/bin/drush --root=$root "$@"
     else
       docker_compose run --rm drush --root=$root "$@"
     fi


### PR DESCRIPTION
In some setups (Unspecified which) drush won't trigger xdebug breakpoints unless the drush command is specifically called with php.
