### PR TITLE
6711: Fixed domain for cron-metrics

### DIFF
--- a/templates/drupal-10/docker-compose.server.yml
+++ b/templates/drupal-10/docker-compose.server.yml
@@ -52,7 +52,7 @@ services:
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}.rule=Host(`${COMPOSE_SERVER_DOMAIN:?}`)"
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}.entrypoints=websecure"
       # Cron-metrics protection.
-      - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}-metrics.rule=Host(`${COMPOSE_DOMAIN:?}`) && PathPrefix(`/cron-metrics`) "
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}-metrics.rule=Host(`${COMPOSE_SERVER_DOMAIN:?}`) && PathPrefix(`/cron-metrics`) "
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}-metrics.middlewares=ITKMetricsAuth@file"
 
   memcached:

--- a/templates/drupal-11/docker-compose.server.yml
+++ b/templates/drupal-11/docker-compose.server.yml
@@ -52,7 +52,7 @@ services:
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}.rule=Host(`${COMPOSE_SERVER_DOMAIN:?}`)"
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}.entrypoints=websecure"
       # Cron-metrics protection.
-      - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}-metrics.rule=Host(`${COMPOSE_DOMAIN:?}`) && PathPrefix(`/cron-metrics`) "
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}-metrics.rule=Host(`${COMPOSE_SERVER_DOMAIN:?}`) && PathPrefix(`/cron-metrics`) "
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}-metrics.middlewares=ITKMetricsAuth@file"
 
   memcached:

--- a/templates/drupal-7/docker-compose.server.yml
+++ b/templates/drupal-7/docker-compose.server.yml
@@ -51,7 +51,7 @@ services:
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}.rule=Host(`${COMPOSE_SERVER_DOMAIN:?}`)"
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}.entrypoints=websecure"
       # Cron-metrics protection.
-      - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}-metrics.rule=Host(`${COMPOSE_DOMAIN:?}`) && PathPrefix(`/cron-metrics`) "
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}-metrics.rule=Host(`${COMPOSE_SERVER_DOMAIN:?}`) && PathPrefix(`/cron-metrics`) "
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}-metrics.middlewares=ITKMetricsAuth@file"
 
   memcached:

--- a/templates/drupal-8/docker-compose.server.yml
+++ b/templates/drupal-8/docker-compose.server.yml
@@ -50,7 +50,7 @@ services:
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}.rule=Host(`${COMPOSE_SERVER_DOMAIN:?}`)"
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}.entrypoints=websecure"
       # Cron-metrics protection.
-      - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}-metrics.rule=Host(`${COMPOSE_DOMAIN:?}`) && PathPrefix(`/cron-metrics`) "
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}-metrics.rule=Host(`${COMPOSE_SERVER_DOMAIN:?}`) && PathPrefix(`/cron-metrics`) "
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}-metrics.middlewares=ITKMetricsAuth@file"
 
   memcached:

--- a/templates/drupal-9/docker-compose.server.yml
+++ b/templates/drupal-9/docker-compose.server.yml
@@ -52,7 +52,7 @@ services:
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}.rule=Host(`${COMPOSE_SERVER_DOMAIN:?}`)"
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}.entrypoints=websecure"
       # Cron-metrics protection.
-      - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}-metrics.rule=Host(`${COMPOSE_DOMAIN:?}`) && PathPrefix(`/cron-metrics`) "
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}-metrics.rule=Host(`${COMPOSE_SERVER_DOMAIN:?}`) && PathPrefix(`/cron-metrics`) "
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}-metrics.middlewares=ITKMetricsAuth@file"
 
   memcached:

--- a/templates/symfony-3/docker-compose.server.yml
+++ b/templates/symfony-3/docker-compose.server.yml
@@ -48,5 +48,5 @@ services:
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}.rule=Host(`${COMPOSE_SERVER_DOMAIN:?}`)"
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}.entrypoints=websecure"
       # Cron-metrics protection.
-      - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}-metrics.rule=Host(`${COMPOSE_DOMAIN:?}`) && PathPrefix(`/cron-metrics`) "
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}-metrics.rule=Host(`${COMPOSE_SERVER_DOMAIN:?}`) && PathPrefix(`/cron-metrics`) "
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}-metrics.middlewares=ITKMetricsAuth@file"

--- a/templates/symfony-4/docker-compose.server.yml
+++ b/templates/symfony-4/docker-compose.server.yml
@@ -48,5 +48,5 @@ services:
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}.rule=Host(`${COMPOSE_SERVER_DOMAIN:?}`)"
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}.entrypoints=websecure"
       # Cron-metrics protection.
-      - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}-metrics.rule=Host(`${COMPOSE_DOMAIN:?}`) && PathPrefix(`/cron-metrics`) "
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}-metrics.rule=Host(`${COMPOSE_SERVER_DOMAIN:?}`) && PathPrefix(`/cron-metrics`) "
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}-metrics.middlewares=ITKMetricsAuth@file"

--- a/templates/symfony-6/docker-compose.server.yml
+++ b/templates/symfony-6/docker-compose.server.yml
@@ -48,5 +48,5 @@ services:
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}.rule=Host(`${COMPOSE_SERVER_DOMAIN:?}`)"
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}.entrypoints=websecure"
       # Cron-metrics protection.
-      - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}-metrics.rule=Host(`${COMPOSE_DOMAIN:?}`) && PathPrefix(`/cron-metrics`) "
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}-metrics.rule=Host(`${COMPOSE_SERVER_DOMAIN:?}`) && PathPrefix(`/cron-metrics`) "
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}-metrics.middlewares=ITKMetricsAuth@file"


### PR DESCRIPTION
https://leantime.itkdev.dk/_#/tickets/showTicket/6711

Fixes domain used for `cron-metrics` endpoint on servers.