### PR TITLE
Added Prettier config for Taskfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Changelog", this file is a reverse-chronological list of merged pull requests.
 
 ## Open PR's
 
+- [PR-142](https://github.com/itk-dev/devops_itkdev-docker/pull/142) - 2026-05-21 -
+  Add Prettier config for Taskfiles
 - [PR-135](https://github.com/itk-dev/devops_itkdev-docker/pull/135) - 2026-01-29 -
   Add Podman support with dynamic machine detection
 - [PR-126](https://github.com/itk-dev/devops_itkdev-docker/pull/126) - 2026-01-05 -

--- a/config/drupal/yaml/.prettierrc.yaml
+++ b/config/drupal/yaml/.prettierrc.yaml
@@ -1,4 +1,4 @@
-# This file is copied from config/symfony/yaml/.prettierrc.yaml in https://github.com/itk-dev/devops_itkdev-docker.
+# This file is copied from config/drupal/yaml/.prettierrc.yaml in https://github.com/itk-dev/devops_itkdev-docker.
 # Feel free to edit the file, but consider making a pull request if you find a general issue with the file.
 
 # https://prettier.io/docs/configuration
@@ -8,11 +8,4 @@ overrides:
       - "Taskfile.{yml,yaml}"
     options:
       tabWidth: 2
-      singleQuote: true
-
-  # Symfony config
-  - files:
-      - "config/**/*.{yml,yaml}"
-    options:
-      tabWidth: 4
       singleQuote: true

--- a/templates/drupal-10/.prettierrc.yaml
+++ b/templates/drupal-10/.prettierrc.yaml
@@ -1,0 +1,1 @@
+../../config/drupal/yaml/.prettierrc.yaml

--- a/templates/drupal-11/.prettierrc.yaml
+++ b/templates/drupal-11/.prettierrc.yaml
@@ -1,0 +1,1 @@
+../../config/drupal/yaml/.prettierrc.yaml

--- a/templates/drupal-8/.prettierrc.yaml
+++ b/templates/drupal-8/.prettierrc.yaml
@@ -1,0 +1,1 @@
+../../config/drupal/yaml/.prettierrc.yaml

--- a/templates/drupal-9/.prettierrc.yaml
+++ b/templates/drupal-9/.prettierrc.yaml
@@ -1,0 +1,1 @@
+../../config/drupal/yaml/.prettierrc.yaml

--- a/templates/drupal/.prettierrc.yaml
+++ b/templates/drupal/.prettierrc.yaml
@@ -1,0 +1,1 @@
+../../config/drupal/yaml/.prettierrc.yaml


### PR DESCRIPTION
Adds Prettier config matching the [Taskfile Style Guide](https://taskfile.dev/docs/styleguide). 

Note: The Taskfile examples use single quotes, but this is not explicitly mentioned in the style guide.