### PR TITLE
fix: audit composer lock file with --locked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Changelog", this file is a reverse-chronological list of merged pull requests.
 
 ## Open PR's
 
+- [PR-143](https://github.com/itk-dev/devops_itkdev-docker/pull/143) - 2026-06-02 -
+  Fixed `composer audit` action to audit the lock file (`--locked`) for
+  compatibility with the latest Composer
 - [PR-135](https://github.com/itk-dev/devops_itkdev-docker/pull/135) - 2026-01-29 -
   Add Podman support with dynamic machine detection
 - [PR-126](https://github.com/itk-dev/devops_itkdev-docker/pull/126) - 2026-01-05 -

--- a/github/workflows/composer.yaml
+++ b/github/workflows/composer.yaml
@@ -76,4 +76,4 @@ jobs:
           docker network create frontend
 
       - run: |
-          docker compose run --rm phpfpm composer audit
+          docker compose run --rm phpfpm composer audit --locked


### PR DESCRIPTION
## Summary

The `composer audit` GitHub Action fails with the latest Composer:

```
No installed packages found. Please run "composer install" before running "audit" or pass "--locked" to audit the lock file.
```

Recent Composer versions no longer audit the lock file by default. The `composer-audit` job does not run `composer install`, so this PR audits the lock file explicitly with `--locked`.

Reproduced in [devops_itksites CI](https://github.com/itk-dev/devops_itksites/actions/runs/26816514408/job/79059558090).

## Files Changed

* `github/workflows/composer.yaml` - `composer audit` → `composer audit --locked` (all template copies are symlinks to this file, so they inherit the fix)
* `CHANGELOG.md` - Added entry under Open PR's

## Test Plan

* Run the Composer workflow against a project with a `composer.lock` using the latest Composer.
* Expected: the `composer-audit` job audits the lock file and passes (or reports advisories) instead of erroring with "No installed packages found".

🤖 Generated with [Claude Code](https://claude.com/claude-code)