### PR TITLE
Add NGINX_FASTCGI_READ_TIMEOUT support to nginx templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Changelog", this file is a reverse-chronological list of merged pull requests.
 
 ## Open PR's
 
+- [PR-144](https://github.com/itk-dev/devops_itkdev-docker/pull/144) - 2026-06-10 -
+  Add `NGINX_FASTCGI_READ_TIMEOUT` support to nginx templates and document the
+  supported `NGINX_*` variables
 - [PR-143](https://github.com/itk-dev/devops_itkdev-docker/pull/143) - 2026-06-02 -
   Fixed `composer audit` action to audit the lock file (`--locked`) for
   compatibility with the latest Composer

--- a/templates/drupal-8/.docker/templates/default.conf.template
+++ b/templates/drupal-8/.docker/templates/default.conf.template
@@ -90,6 +90,7 @@ server {
 
         fastcgi_intercept_errors on;
         fastcgi_pass ${NGINX_FPM_SERVICE};
+        fastcgi_read_timeout ${NGINX_FASTCGI_READ_TIMEOUT};
     }
 
     location ~ ^/sites/.*/files/styles/ {

--- a/templates/drupal-8/docker-compose.server.yml
+++ b/templates/drupal-8/docker-compose.server.yml
@@ -42,6 +42,8 @@ services:
       NGINX_WEB_ROOT: /app/web
       NGINX_PORT: 8080
       NGINX_MAX_BODY_SIZE: 5M
+      # Timeout for reading a response from PHP-FPM (https://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_read_timeout)
+      NGINX_FASTCGI_READ_TIMEOUT: 60s
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=frontend"

--- a/templates/drupal-8/docker-compose.yml
+++ b/templates/drupal-8/docker-compose.yml
@@ -69,6 +69,8 @@ services:
       NGINX_WEB_ROOT: /app/web
       NGINX_PORT: 8080
       NGINX_MAX_BODY_SIZE: 5M
+      # Timeout for reading a response from PHP-FPM (https://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_read_timeout)
+      NGINX_FASTCGI_READ_TIMEOUT: 60s
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=frontend"

--- a/templates/drupal-9/.docker/templates/default.conf.template
+++ b/templates/drupal-9/.docker/templates/default.conf.template
@@ -90,6 +90,7 @@ server {
 
         fastcgi_intercept_errors on;
         fastcgi_pass ${NGINX_FPM_SERVICE};
+        fastcgi_read_timeout ${NGINX_FASTCGI_READ_TIMEOUT};
     }
 
     location ~ ^/sites/.*/files/styles/ {

--- a/templates/drupal-9/docker-compose.server.yml
+++ b/templates/drupal-9/docker-compose.server.yml
@@ -42,6 +42,8 @@ services:
       NGINX_WEB_ROOT: /app/web
       NGINX_PORT: 8080
       NGINX_MAX_BODY_SIZE: 5M
+      # Timeout for reading a response from PHP-FPM (https://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_read_timeout)
+      NGINX_FASTCGI_READ_TIMEOUT: 60s
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=frontend"

--- a/templates/drupal-9/docker-compose.yml
+++ b/templates/drupal-9/docker-compose.yml
@@ -69,6 +69,8 @@ services:
       NGINX_WEB_ROOT: /app/web
       NGINX_PORT: 8080
       NGINX_MAX_BODY_SIZE: 5M
+      # Timeout for reading a response from PHP-FPM (https://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_read_timeout)
+      NGINX_FASTCGI_READ_TIMEOUT: 60s
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=frontend"

--- a/templates/drupal/.docker/templates/default.conf.template
+++ b/templates/drupal/.docker/templates/default.conf.template
@@ -93,6 +93,7 @@ server {
 
         fastcgi_intercept_errors on;
         fastcgi_pass ${NGINX_FPM_SERVICE};
+        fastcgi_read_timeout ${NGINX_FASTCGI_READ_TIMEOUT};
     }
 
     # Enforce clean URLs

--- a/templates/drupal/README.md
+++ b/templates/drupal/README.md
@@ -4,7 +4,7 @@ This is the current generic template for Drupal projects.
 
 Specific version templates are created by symlinking to this folder, e.g.
 
-``` text
+```text
 templates/drupal-11
 ├── .docker -> ../drupal/.docker
 ├── .twig-cs-fixer.dist.php -> ../../config/drupal/twig/.twig-cs-fixer.dist.php
@@ -16,3 +16,30 @@ templates/drupal-11
 
 > [!NOTE]
 > GitHub workflow files and code check config files are handled in another symlink show.
+
+## Nginx configuration
+
+The `nginx` service uses the official
+[`nginxinc/nginx-unprivileged`](https://hub.docker.com/r/nginxinc/nginx-unprivileged) image, which renders the config
+templates in [`.docker/templates`](.docker/templates) with `envsubst` on container start (see [“Using environment
+variables in nginx configuration” in the nginx image documentation](https://hub.docker.com/_/nginx)).
+
+Only variables actually referenced in [`default.conf.template`](.docker/templates/default.conf.template) are
+substituted – any other `NGINX_*` environment variable is silently ignored. The supported variables are:
+
+| Variable                     | Nginx directive                                                                                            | Description                                     |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| `NGINX_PORT`                 | [`listen`](https://nginx.org/en/docs/http/ngx_http_core_module.html#listen)                                | Port nginx listens on                           |
+| `NGINX_WEB_ROOT`             | [`root`](https://nginx.org/en/docs/http/ngx_http_core_module.html#root)                                    | Document root                                   |
+| `NGINX_MAX_BODY_SIZE`        | [`client_max_body_size`](https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size)    | Maximum request (upload) size                   |
+| `NGINX_FPM_SERVICE`          | [`fastcgi_pass`](https://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_pass)                 | `host:port` of the PHP-FPM service              |
+| `NGINX_FASTCGI_READ_TIMEOUT` | [`fastcgi_read_timeout`](https://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_read_timeout) | Timeout for reading a response from PHP-FPM     |
+| `NGINX_CRON_METRICS`         | [`proxy_pass`](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass)                       | `host:port` of the supercronic metrics endpoint |
+
+All of these must be set on the `nginx` service's `environment` (as done in
+[`docker-compose.yml`](docker-compose.yml)) – `envsubst` has no default value syntax, so an unset variable is replaced
+with an empty string and nginx will fail to start.
+
+> [!TIP]
+> When increasing `NGINX_FASTCGI_READ_TIMEOUT`, remember to increase `PHP_MAX_EXECUTION_TIME` on the `phpfpm` service
+> accordingly.

--- a/templates/drupal/docker-compose.server.yml
+++ b/templates/drupal/docker-compose.server.yml
@@ -42,6 +42,8 @@ services:
       NGINX_WEB_ROOT: /app/web
       NGINX_PORT: 8080
       NGINX_MAX_BODY_SIZE: 5M
+      # Timeout for reading a response from PHP-FPM (https://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_read_timeout)
+      NGINX_FASTCGI_READ_TIMEOUT: 60s
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=frontend"

--- a/templates/drupal/docker-compose.yml
+++ b/templates/drupal/docker-compose.yml
@@ -69,6 +69,8 @@ services:
       NGINX_WEB_ROOT: /app/web
       NGINX_PORT: 8080
       NGINX_MAX_BODY_SIZE: 5M
+      # Timeout for reading a response from PHP-FPM (https://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_read_timeout)
+      NGINX_FASTCGI_READ_TIMEOUT: 60s
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=frontend"

--- a/templates/symfony/.docker/templates/default.conf.template
+++ b/templates/symfony/.docker/templates/default.conf.template
@@ -37,6 +37,7 @@ server {
         fastcgi_busy_buffers_size 64k;
 
         fastcgi_pass ${NGINX_FPM_SERVICE};
+        fastcgi_read_timeout ${NGINX_FASTCGI_READ_TIMEOUT};
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;
 

--- a/templates/symfony/README.md
+++ b/templates/symfony/README.md
@@ -4,7 +4,7 @@ This is the current generic template for Symfony projects.
 
 Specific version templates are created by symlinking to this folder, e.g.
 
-``` text
+```text
 templates/symfony-8
 ├── .docker -> ../symfony/.docker
 ├── docker-compose.dev.yml -> ../symfony/docker-compose.dev.yml
@@ -15,3 +15,30 @@ templates/symfony-8
 
 > [!NOTE]
 > GitHub workflow files and code check config files are handled in another symlink show.
+
+## Nginx configuration
+
+The `nginx` service uses the official
+[`nginxinc/nginx-unprivileged`](https://hub.docker.com/r/nginxinc/nginx-unprivileged) image, which renders the config
+templates in [`.docker/templates`](.docker/templates) with `envsubst` on container start (see [“Using environment
+variables in nginx configuration” in the nginx image documentation](https://hub.docker.com/_/nginx)).
+
+Only variables actually referenced in [`default.conf.template`](.docker/templates/default.conf.template) are
+substituted – any other `NGINX_*` environment variable is silently ignored. The supported variables are:
+
+| Variable                     | Nginx directive                                                                                            | Description                                     |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| `NGINX_PORT`                 | [`listen`](https://nginx.org/en/docs/http/ngx_http_core_module.html#listen)                                | Port nginx listens on                           |
+| `NGINX_WEB_ROOT`             | [`root`](https://nginx.org/en/docs/http/ngx_http_core_module.html#root)                                    | Document root                                   |
+| `NGINX_MAX_BODY_SIZE`        | [`client_max_body_size`](https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size)    | Maximum request (upload) size                   |
+| `NGINX_FPM_SERVICE`          | [`fastcgi_pass`](https://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_pass)                 | `host:port` of the PHP-FPM service              |
+| `NGINX_FASTCGI_READ_TIMEOUT` | [`fastcgi_read_timeout`](https://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_read_timeout) | Timeout for reading a response from PHP-FPM     |
+| `NGINX_CRON_METRICS`         | [`proxy_pass`](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass)                       | `host:port` of the supercronic metrics endpoint |
+
+All of these must be set on the `nginx` service's `environment` (as done in
+[`docker-compose.yml`](docker-compose.yml)) – `envsubst` has no default value syntax, so an unset variable is replaced
+with an empty string and nginx will fail to start.
+
+> [!TIP]
+> When increasing `NGINX_FASTCGI_READ_TIMEOUT`, remember to increase `PHP_MAX_EXECUTION_TIME` on the `phpfpm` service
+> accordingly.

--- a/templates/symfony/docker-compose.server.yml
+++ b/templates/symfony/docker-compose.server.yml
@@ -38,6 +38,8 @@ services:
       NGINX_WEB_ROOT: /app/public
       NGINX_PORT: 8080
       NGINX_MAX_BODY_SIZE: 5M
+      # Timeout for reading a response from PHP-FPM (https://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_read_timeout)
+      NGINX_FASTCGI_READ_TIMEOUT: 60s
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=frontend"

--- a/templates/symfony/docker-compose.yml
+++ b/templates/symfony/docker-compose.yml
@@ -65,6 +65,8 @@ services:
       NGINX_WEB_ROOT: /app/public
       NGINX_PORT: 8080
       NGINX_MAX_BODY_SIZE: 5M
+      # Timeout for reading a response from PHP-FPM (https://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_read_timeout)
+      NGINX_FASTCGI_READ_TIMEOUT: 60s
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=frontend"


### PR DESCRIPTION
## Summary

`NGINX_FASTCGI_READ_TIMEOUT` had no effect with the current nginx templates: the nginx config templates never contained a `fastcgi_read_timeout` directive, so nginx always used its built-in 60s default and the environment variable was silently ignored by the `nginxinc/nginx-unprivileged` envsubst entrypoint (only variables literally referenced in a template are substituted).

Git history shows the variable never existed in this repo — the only prior timeout handling was a hardcoded `fastcgi_read_timeout 300;` in the long-removed `ddbcms` template (a5b5e25).

## Features Added

* `fastcgi_read_timeout ${NGINX_FASTCGI_READ_TIMEOUT}` in all nginx config templates, so the timeout can be configured per project
* Default value (`60s`, matching nginx's built-in default) with a documenting comment in all docker compose templates
* New "Nginx configuration" section in the Drupal and Symfony template READMEs documenting exactly which `NGINX_*` variables are supported, with links to the nginx directive docs and to the [nginx image envsubst documentation](https://hub.docker.com/_/nginx) ("Using environment variables in nginx configuration")

## Files Changed

* `templates/{drupal,drupal-8,drupal-9,symfony}/.docker/templates/default.conf.template` - add `fastcgi_read_timeout` directive
* `templates/{drupal,drupal-8,drupal-9,symfony}/docker-compose.yml` and `docker-compose.server.yml` - add `NGINX_FASTCGI_READ_TIMEOUT: 60s` with doc comment (drupal-10/11 and symfony-6/7/8 pick this up via symlinks)
* `templates/{drupal,symfony}/README.md` - document supported `NGINX_*` variables and envsubst behaviour

## Test Plan

* Render each changed template with the real image entrypoint and validate:

  ```sh
  docker run --rm \
    -e NGINX_PORT=8080 -e NGINX_WEB_ROOT=/tmp -e NGINX_MAX_BODY_SIZE=5M \
    -e NGINX_FPM_SERVICE=127.0.0.1:9000 -e NGINX_CRON_METRICS=127.0.0.1:9746 \
    -e NGINX_FASTCGI_READ_TIMEOUT=60s \
    -v "$PWD/templates/drupal/.docker/templates:/etc/nginx/templates:ro" \
    nginxinc/nginx-unprivileged:alpine sh -c '/docker-entrypoint.sh nginx -t'
  ```

  Expected: `nginx -t` reports success and the rendered `/etc/nginx/conf.d/default.conf` contains `fastcgi_read_timeout 60s;` — verified locally for drupal, drupal-8/9 and symfony templates
* `docker compose run --rm prettier 'templates/**/*.{yml,yaml}' --check` passes
* `docker compose run --rm markdownlint markdownlint 'templates/**/*.md'` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)