### PR TITLE
ci: update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 2
 

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -17,8 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Check that Github Actions documentation is up to date
     steps:
-      - uses: actions/checkout@v6
-      - uses: go-task/setup-task@v1
+      - uses: actions/checkout@v7
+      - uses: go-task/setup-task@v2
 
       # https://github.com/mxschmitt/action-tmate?tab=readme-ov-file#manually-triggered-debug
       # Enable tmate debugging if debug logging is enabled (cf.
@@ -38,8 +38,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Check that Github Actions template headers are up to date
     steps:
-      - uses: actions/checkout@v6
-      - uses: go-task/setup-task@v1
+      - uses: actions/checkout@v7
+      - uses: go-task/setup-task@v2
       - run: |
           task github-actions:template-headers:update --yes
       # Check that files have not changed.
@@ -50,8 +50,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Check that config file headers are up to date
     steps:
-      - uses: actions/checkout@v6
-      - uses: go-task/setup-task@v1
+      - uses: actions/checkout@v7
+      - uses: go-task/setup-task@v2
       - run: |
           task github-actions:config-headers:update --yes
       # Check that files have not changed.
@@ -62,8 +62,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Check that workflow and config file links are up to date
     steps:
-      - uses: actions/checkout@v6
-      - uses: go-task/setup-task@v1
+      - uses: actions/checkout@v7
+      - uses: go-task/setup-task@v2
       - run: |
           task github-actions:link --yes
       # Check that files have not changed.

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Create docker network
         run: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -34,7 +34,7 @@ jobs:
           - symfony-8
     name: Validate compose (${{ matrix.version }})
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Validate local docker compose files
         run: |
@@ -59,7 +59,7 @@ jobs:
 
     name: Validate nginx conf (${{ matrix.version }}/${{ matrix.compose_file}})
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Create docker network
         run: |
@@ -80,7 +80,7 @@ jobs:
 
     name: Test template install (${{ matrix.version }})
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install and check template
         run: |
@@ -108,8 +108,8 @@ jobs:
 
     name: Check that Bash completion is up to date
     steps:
-      - uses: actions/checkout@v6
-      - uses: go-task/setup-task@v1
+      - uses: actions/checkout@v7
+      - uses: go-task/setup-task@v2
 
       - name: Build completion
         run: task completion:build

--- a/.github/workflows/shell.yaml
+++ b/.github/workflows/shell.yaml
@@ -9,8 +9,8 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: go-task/setup-task@v1
+      - uses: actions/checkout@v7
+      - uses: go-task/setup-task@v2
 
       - run: |
           task lint:shell-script

--- a/.github/workflows/yaml.yaml
+++ b/.github/workflows/yaml.yaml
@@ -35,7 +35,7 @@ jobs:
   yaml-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Create docker network
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Changelog", this file is a reverse-chronological list of merged pull requests.
 
 ## Open PR's
 
+- [PR-XXX](https://github.com/itk-dev/devops_itkdev-docker/pull/XXX) - 2026-07-08 -
+  Updated GitHub Actions to latest versions (`actions/checkout` to `v7`,
+  `go-task/setup-task` to `v2`) in workflow templates and repository CI
 - [PR-143](https://github.com/itk-dev/devops_itkdev-docker/pull/143) - 2026-06-02 -
   Fixed `composer audit` action to audit the lock file (`--locked`) for
   compatibility with the latest Composer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Changelog", this file is a reverse-chronological list of merged pull requests.
 
 ## Open PR's
 
-- [PR-XXX](https://github.com/itk-dev/devops_itkdev-docker/pull/XXX) - 2026-07-08 -
+- [PR-145](https://github.com/itk-dev/devops_itkdev-docker/pull/145) - 2026-07-08 -
   Updated GitHub Actions to latest versions (`actions/checkout` to `v7`,
   `go-task/setup-task` to `v2`) in workflow templates and repository CI
 - [PR-143](https://github.com/itk-dev/devops_itkdev-docker/pull/143) - 2026-06-02 -

--- a/github/workflows/changelog.yaml
+++ b/github/workflows/changelog.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 2
 

--- a/github/workflows/composer.yaml
+++ b/github/workflows/composer.yaml
@@ -44,7 +44,7 @@ jobs:
   composer-validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Create docker network
         run: |
@@ -56,7 +56,7 @@ jobs:
   composer-normalized:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Create docker network
         run: |
@@ -69,7 +69,7 @@ jobs:
   composer-audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Create docker network
         run: |

--- a/github/workflows/drupal-module/javascript.yaml
+++ b/github/workflows/drupal-module/javascript.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Create docker network
         run: |

--- a/github/workflows/drupal-module/php.yaml
+++ b/github/workflows/drupal-module/php.yaml
@@ -54,7 +54,7 @@ jobs:
     name: PHP - Check Coding Standards
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Create docker network
         run: |

--- a/github/workflows/drupal-module/styles.yaml
+++ b/github/workflows/drupal-module/styles.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Create docker network
         run: |

--- a/github/workflows/drupal/javascript.yaml
+++ b/github/workflows/drupal/javascript.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Create docker network
         run: |

--- a/github/workflows/drupal/php.yaml
+++ b/github/workflows/drupal/php.yaml
@@ -54,7 +54,7 @@ jobs:
     name: PHP - Check Coding Standards
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Create docker network
         run: |

--- a/github/workflows/drupal/site.yaml
+++ b/github/workflows/drupal/site.yaml
@@ -33,7 +33,7 @@ jobs:
     name: Check that site can be installed
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Create docker network
         run: |
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Install site from our base ref
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.base_ref }}
 
@@ -130,7 +130,7 @@ jobs:
           sudo chmod -Rv a+w web/sites/default || true
 
       # Update site using our updated code.
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           # Keep our local settings (cf.
           # https://github.com/actions/checkout?tab=readme-ov-file#usage)

--- a/github/workflows/drupal/styles.yaml
+++ b/github/workflows/drupal/styles.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Create docker network
         run: |

--- a/github/workflows/markdown.yaml
+++ b/github/workflows/markdown.yaml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Create docker network
         run: |

--- a/github/workflows/symfony/javascript.yaml
+++ b/github/workflows/symfony/javascript.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Create docker network
         run: |

--- a/github/workflows/symfony/php.yaml
+++ b/github/workflows/symfony/php.yaml
@@ -54,7 +54,7 @@ jobs:
     name: PHP - Check Coding Standards
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Create docker network
         run: |

--- a/github/workflows/symfony/styles.yaml
+++ b/github/workflows/symfony/styles.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Create docker network
         run: |

--- a/github/workflows/twig.yaml
+++ b/github/workflows/twig.yaml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Create docker network
         run: |

--- a/github/workflows/yaml.yaml
+++ b/github/workflows/yaml.yaml
@@ -35,7 +35,7 @@ jobs:
   yaml-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Create docker network
         run: |


### PR DESCRIPTION
Bump all GitHub Actions used in the workflow templates and this repository's own CI to their latest major versions.

## Changes

- `actions/checkout`: `v6` → `v7` across all `github/workflows/**` templates and `.github/workflows/**`
- `go-task/setup-task`: `v1` → `v2` in `.github/workflows/**` (documentation, shell, pr)
- `mxschmitt/action-tmate`: already on the latest major (`v3`), unchanged

## Why

Keeps the distributed workflow templates and repository CI on maintained action releases, picking up Node 24 runtime support and dependency/security updates. Part of aligning our templates with the improvements in itk-dev/event-database-imports#98.