### PR TITLE
ci: cache Composer dependencies in workflow templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Changelog", this file is a reverse-chronological list of merged pull requests.
 
 ## Open PR's
 
+- [PR-146](https://github.com/itk-dev/devops_itkdev-docker/pull/146) - 2026-07-08 -
+  Cache Composer dependencies (`vendor`) in the Composer, Twig and PHP workflow
+  templates to speed up installs and avoid package registry rate limits. The
+  cache key hashes both `composer.lock` and `docker-compose.yml` so a PHP image
+  bump invalidates the cache
 - [PR-145](https://github.com/itk-dev/devops_itkdev-docker/pull/145) - 2026-07-08 -
   Updated GitHub Actions to latest versions (`actions/checkout` to `v7`,
   `go-task/setup-task` to `v2`) in workflow templates and repository CI

--- a/github/workflows/composer.yaml
+++ b/github/workflows/composer.yaml
@@ -62,6 +62,13 @@ jobs:
         run: |
           docker network create frontend
 
+      - name: Cache Composer dependencies
+        uses: actions/cache@v6
+        with:
+          path: vendor
+          key: composer-${{ hashFiles('composer.lock', 'docker-compose.yml') }}
+          restore-keys: composer-
+
       - run: |
           docker compose run --rm phpfpm composer install
           docker compose run --rm phpfpm composer normalize --dry-run

--- a/github/workflows/drupal-module/php.yaml
+++ b/github/workflows/drupal-module/php.yaml
@@ -60,6 +60,13 @@ jobs:
         run: |
           docker network create frontend
 
+      - name: Cache Composer dependencies
+        uses: actions/cache@v6
+        with:
+          path: vendor
+          key: composer-${{ hashFiles('composer.lock', 'docker-compose.yml') }}
+          restore-keys: composer-
+
       - run: |
           docker compose run --rm phpfpm composer install
           docker compose run --rm phpfpm vendor/bin/phpcs

--- a/github/workflows/drupal/php.yaml
+++ b/github/workflows/drupal/php.yaml
@@ -60,6 +60,13 @@ jobs:
         run: |
           docker network create frontend
 
+      - name: Cache Composer dependencies
+        uses: actions/cache@v6
+        with:
+          path: vendor
+          key: composer-${{ hashFiles('composer.lock', 'docker-compose.yml') }}
+          restore-keys: composer-
+
       - run: |
           docker compose run --rm phpfpm composer install
           docker compose run --rm phpfpm vendor/bin/phpcs

--- a/github/workflows/symfony/php.yaml
+++ b/github/workflows/symfony/php.yaml
@@ -60,6 +60,13 @@ jobs:
         run: |
           docker network create frontend
 
+      - name: Cache Composer dependencies
+        uses: actions/cache@v6
+        with:
+          path: vendor
+          key: composer-${{ hashFiles('composer.lock', 'docker-compose.yml') }}
+          restore-keys: composer-
+
       - run: |
           docker compose run --rm phpfpm composer install
           # https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/usage.rst#the-check-command

--- a/github/workflows/twig.yaml
+++ b/github/workflows/twig.yaml
@@ -50,6 +50,13 @@ jobs:
         run: |
           docker network create frontend
 
+      - name: Cache Composer dependencies
+        uses: actions/cache@v6
+        with:
+          path: vendor
+          key: composer-${{ hashFiles('composer.lock', 'docker-compose.yml') }}
+          restore-keys: composer-
+
       - run: |
           docker compose run --rm phpfpm composer install
           docker compose run --rm phpfpm vendor/bin/twig-cs-fixer lint


### PR DESCRIPTION
Add `actions/cache` for the `vendor` directory to the workflow templates that run `composer install` purely to obtain dependencies for a check.

## Changes

- Cache `vendor` (keyed on `composer.lock`, with a `composer-` restore fallback) in:
  - `github/workflows/composer.yaml` (normalize job)
  - `github/workflows/twig.yaml`
  - `github/workflows/drupal/php.yaml`
  - `github/workflows/drupal-module/php.yaml`
  - `github/workflows/symfony/php.yaml`

## Why

On a cache hit `composer install` reuses the restored `vendor` instead of re-downloading every dependency, cutting job time and reducing the risk of hitting package registry rate limits. Mirrors the Composer caching added in itk-dev/event-database-imports#98. The validate/audit jobs are untouched since they do not install dependencies.