### PR TITLE
ci: pull phpfpm and its dependencies up front in workflow templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Changelog", this file is a reverse-chronological list of merged pull requests.
 
 ## Open PR's
 
+- [PR-147](https://github.com/itk-dev/devops_itkdev-docker/pull/147) - 2026-07-08 -
+  Pull `phpfpm` and its dependencies up front
+  (`docker compose pull --quiet --include-deps phpfpm`) in the Composer, Twig
+  and PHP workflow templates so the images download in parallel before the job
+  runs
 - [PR-145](https://github.com/itk-dev/devops_itkdev-docker/pull/145) - 2026-07-08 -
   Updated GitHub Actions to latest versions (`actions/checkout` to `v7`,
   `go-task/setup-task` to `v2`) in workflow templates and repository CI

--- a/github/workflows/composer.yaml
+++ b/github/workflows/composer.yaml
@@ -50,6 +50,9 @@ jobs:
         run: |
           docker network create frontend
 
+      - name: Pull container images
+        run: docker compose pull --quiet --include-deps phpfpm
+
       - run: |
           docker compose run --rm phpfpm composer validate --strict
 
@@ -61,6 +64,9 @@ jobs:
       - name: Create docker network
         run: |
           docker network create frontend
+
+      - name: Pull container images
+        run: docker compose pull --quiet --include-deps phpfpm
 
       - run: |
           docker compose run --rm phpfpm composer install
@@ -74,6 +80,9 @@ jobs:
       - name: Create docker network
         run: |
           docker network create frontend
+
+      - name: Pull container images
+        run: docker compose pull --quiet --include-deps phpfpm
 
       - run: |
           docker compose run --rm phpfpm composer audit --locked

--- a/github/workflows/drupal-module/php.yaml
+++ b/github/workflows/drupal-module/php.yaml
@@ -60,6 +60,9 @@ jobs:
         run: |
           docker network create frontend
 
+      - name: Pull container images
+        run: docker compose pull --quiet --include-deps phpfpm
+
       - run: |
           docker compose run --rm phpfpm composer install
           docker compose run --rm phpfpm vendor/bin/phpcs

--- a/github/workflows/drupal/php.yaml
+++ b/github/workflows/drupal/php.yaml
@@ -60,6 +60,9 @@ jobs:
         run: |
           docker network create frontend
 
+      - name: Pull container images
+        run: docker compose pull --quiet --include-deps phpfpm
+
       - run: |
           docker compose run --rm phpfpm composer install
           docker compose run --rm phpfpm vendor/bin/phpcs

--- a/github/workflows/symfony/php.yaml
+++ b/github/workflows/symfony/php.yaml
@@ -60,6 +60,9 @@ jobs:
         run: |
           docker network create frontend
 
+      - name: Pull container images
+        run: docker compose pull --quiet --include-deps phpfpm
+
       - run: |
           docker compose run --rm phpfpm composer install
           # https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/usage.rst#the-check-command

--- a/github/workflows/twig.yaml
+++ b/github/workflows/twig.yaml
@@ -50,6 +50,9 @@ jobs:
         run: |
           docker network create frontend
 
+      - name: Pull container images
+        run: docker compose pull --quiet --include-deps phpfpm
+
       - run: |
           docker compose run --rm phpfpm composer install
           docker compose run --rm phpfpm vendor/bin/twig-cs-fixer lint


### PR DESCRIPTION
Pull the `phpfpm` service and its dependencies up front with `docker compose pull --quiet --include-deps phpfpm`, so the images download in parallel before the job runs instead of lazily during `docker compose run`.

## Changes

- Add a "Pull container images" step to the workflow templates whose jobs run in `phpfpm`:
  - `github/workflows/composer.yaml` (validate, normalize, audit)
  - `github/workflows/twig.yaml`
  - `github/workflows/drupal/php.yaml`
  - `github/workflows/drupal-module/php.yaml`
  - `github/workflows/symfony/php.yaml`

## Why

`phpfpm` declares `depends_on: mariadb` (and `memcached` for Drupal), so `docker compose run --rm phpfpm …` brings up several services. Pulling with `--include-deps` up front fetches those images in parallel before the run, for faster and cleaner jobs.

## Notes

- Only applied where it helps. The Prettier/markdownlint workflows (YAML, Markdown, JavaScript, Styles) run a single dependency-less image, so an up-front pull would add nothing over the pull `run` already does — left unchanged.
- `github/workflows/drupal/site.yaml` already pulls the full stack up front (`docker compose pull`) and is unchanged.
- Mirrors the up-front pull strategy adopted in itk-dev/event-database-imports#98.